### PR TITLE
Changes queue_claim_jobs to select failed claims rather than ignored

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -348,7 +348,7 @@ class User < ApplicationRecord
 
   def queue_claim_jobs
     # claims.notified.find_each { |claim| claim.queue_claim_job }
-    claims.ignored.find_each(&:queue_claim_job)
+    claims.failed.find_each(&:queue_claim_job)
   end
 
   def get_data(options = {})

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,16 +84,16 @@ describe User, type: :model, vcr: true, elasticsearch: true do
     end
   end
 
-  describe "claims from notifications" do
+  describe "claims from failed" do
     subject { FactoryBot.create(:valid_user) }
 
-    let!(:claim) { FactoryBot.create(:claim, user: subject, orcid: "0000-0001-6528-2027", doi: "10.6084/M9.FIGSHARE.1041821", state: "notified") }
+    let!(:claim) { FactoryBot.create(:claim, user: subject, orcid: "0000-0001-6528-2027", doi: "10.6084/M9.FIGSHARE.1041821", state: "failed") }
 
     it "queue_claims_jobs" do
       subject.queue_claim_jobs
       expect(subject.claims.count).to eq(1)
       updated_claim = subject.claims.first
-      expect(updated_claim.state).to eq("notified")
+      expect(updated_claim.state).to eq("failed")
     end
   end
 end


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Changes the User model `queue_claim_job` function to select "failed" claims rather than "ignored" claims. The change allows the following rake task to be used as expected. The function is also called on User create. 

https://github.com/datacite/volpino/blob/6906c2c0f79b0be2783927324b145f6a62ae2fdb/lib/tasks/claim.rake#L159

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

- [x] Are there "ignored" claims that will be affected by this change?
- [x] Should the function be called on User create? What function does this have?
- [x] Should the function also be called when an ORCID token is added or changed?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
