### PR TITLE
Upcases orcid when creating orcid_client models in the Claim model

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -284,11 +284,11 @@ class Claim < ApplicationRecord
     # Note that if this is ever intended in future to support claiming for non datacite dois
     # Then we will need to change following to be looked up from a better location
     agency = "datacite"
-    Work.new(doi: doi, orcid: orcid, orcid_token: orcid_token, put_code: put_code, sandbox: sandbox, agency: agency)
+    Work.new(doi: doi, orcid: orcid.upcase, orcid_token: orcid_token, put_code: put_code, sandbox: sandbox, agency: agency)
   end
 
   def notification
-    Notification.new(doi: doi, orcid: orcid, notification_access_token: ENV["NOTIFICATION_ACCESS_TOKEN"], put_code: put_code, subject: SUBJECT, intro: INTRO)
+    Notification.new(doi: doi, orcid: orcid.upcase, notification_access_token: ENV["NOTIFICATION_ACCESS_TOKEN"], put_code: put_code, subject: SUBJECT, intro: INTRO)
   end
 
   def without_control(s)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -96,4 +96,16 @@ describe User, type: :model, vcr: true, elasticsearch: true do
       expect(updated_claim.state).to eq("failed")
     end
   end
+
+  describe "uid containing lowercase x" do
+    subject { FactoryBot.create(:valid_user, uid: "0000-0002-1111-827x") }
+
+    let!(:claim) { FactoryBot.create(:claim, user: subject, orcid: "0000-0002-1111-827x", doi: "10.6084/M9.FIGSHARE.1041821", state: "failed") }
+
+    it "creates Claim work and notification attributes with capital X for ORCID API" do
+      expect(claim.work.orcid).to eq("0000-0002-1111-827X")
+      expect(claim.notification.orcid).to eq("0000-0002-1111-827X")
+      expect(subject.claims.first.doi).to eq("10.6084/M9.FIGSHARE.1041821")
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: #115 

## Approach
<!--- _How does this change address the problem?_ -->

Upcases `orcid`s when creating `orcid_client` Work and Notification objects in the Claim model. The `orcid` attribute is used to construct ORCID API request URLs, which may require uppercase characters for ORCID's pattern matching. Because `orcid`s are currently encoded with lowercase characters, this may be causing the 404 errors some users are seeing.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->

> Looking at ORCID's old nginx code, the pattern match for the API reverse proxy has always been uppercase X. Lower has probably never worked.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
