### PR TITLE
Removes the the option in settings form to set the User is_public attribute

### DIFF
--- a/app/views/settings/_show.html.erb
+++ b/app/views/settings/_show.html.erb
@@ -10,7 +10,6 @@
             <div class="row">
               <div class='col-md-10 col-md-offset-2'>
                 <div class="form-group">
-                  <%= f.input :is_public, label: "Record is public", input_html: { class: "form-user" } %>
                   <%= f.input :auto_update, label: "Auto-Update is enabled", input_html: { class: "form-user" } %>
                   <%= f.input :beta_tester, label: "Beta Tester", input_html: { class: "form-user" } %>
                 </div>
@@ -56,12 +55,6 @@
         </div>
         <div class="panel-body">
           <dl class="dl-horizontal">
-            <dt>Record</dt>
-            <% if @user.is_public %>
-              <dd>is public</dd>
-            <% else %>
-              <dd class="text-info">is private</dd>
-            <% end %>
             <dt>Auto-Update</dt>
             <% if @user.auto_update %>
               <dd>is enabled</dd>


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Currently, the User `is_public` attribute is not used in DataCite systems. This PR removes the option to set the attribute in user settings.

## Approach
<!--- _How does this change address the problem?_ -->

Removes the ability to set and view the `is_public` attribute in the Profiles user form.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
