### PR TITLE
move directives out of the server block

### DIFF
--- a/vendor/docker/webapp.conf
+++ b/vendor/docker/webapp.conf
@@ -1,3 +1,6 @@
+passenger_max_request_queue_size 200;
+passenger_max_pool_size 15;
+
 server {
     listen 80 default_server;
     server_name _;
@@ -8,8 +11,6 @@ server {
     passenger_ruby /usr/bin/ruby;
     passenger_preload_bundler on;
 
-    passenger_max_request_queue_size 200;
-    passenger_max_pool_size 15;
     passenger_min_instances 5;
     
     merge_slashes off;


### PR DESCRIPTION
## Purpose
Move the directives that need to be in the `http` block out of the `server` block. They are left in the `webapp.conf` file because it is included inside the `http` block of `/etc/nginx/nginx.conf` by the `include /etc/nginx/sites-enabled/*;` directive


closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
