### PR TITLE
Use different ORCID client ID for Search & Link and auto-update

### DIFF
--- a/app/controllers/users/orcid_controller.rb
+++ b/app/controllers/users/orcid_controller.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+
+module Users
+  class OrcidController < ApplicationController
+    BASE_URL = "#{ENV["ORCID_URL"]}/oauth"
+    CLIENT_ID = ENV["ORCID_SEARCH_AND_LINK_CLIENT_ID"]
+    CLIENT_SECRET = ENV["ORCID_SEARCH_AND_LINK_CLIENT_SECRET"]
+
+    before_action :load_user
+
+    def search_and_link_auth
+      response_type = "code"
+      scope = "/authenticate"
+      redirect_uri = ENV["ORCID_SEARCH_AND_LINK_REDIRECT_URI"]
+
+      auth_url = "#{BASE_URL}/authorize?client_id=#{CLIENT_ID}&response_type=#{response_type}&scope=#{scope}&redirect_uri=#{redirect_uri}"
+
+      redirect_to auth_url
+    end
+
+    def search_and_link_callback
+      conn = Faraday.new(BASE_URL + "/token")
+
+      body = {
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        grant_type: "authorization_code",
+        code: params[:code],
+      }
+
+      response = conn.post do |req|
+        req.headers["Accept"] = "application/json"
+        req.body = body
+      end
+
+      if response.success?
+        tokens = JSON.parse(response.body)
+        expires_at = Time.now.utc + tokens["expires_in"].seconds
+
+        @user.update(orcid_search_and_link_access_token: tokens["access_token"],
+                     orcid_search_and_link_refresh_token: tokens["refresh_token"],
+                     orcid_search_and_link_expires_at: expires_at)
+      else
+        puts "Error exchanging code for tokens: #{response.status} - #{response.body}"
+        nil
+      end
+
+      redirect_to stored_location_for(:user) || setting_path("me")
+    end
+
+    def search_and_link_refresh
+      conn = Faraday.new(BASE_URL + "/token")
+
+      body = {
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        refresh_token: @user.orcid_search_and_link_refresh_token,
+        grant_type: "refresh_token",
+        code: params[:code],
+      }
+
+      response = conn.post do |req|
+        req.body = body
+      end
+
+      if response.success?
+        tokens = JSON.parse(response.body)
+        expires_at = Time.now.utc + tokens["expires_in"].seconds
+
+        @user.update(orcid_search_and_link_access_token: tokens["access_token"],
+                     orcid_search_and_link_refresh_token: tokens["refresh_token"],
+                     orcid_search_and_link_expires_at: expires_at)
+      else
+        puts "Error refreshing tokens: #{response.status} - #{response.body}"
+        nil
+      end
+
+      redirect_to stored_location_for(:user) || setting_path("me")
+    end
+
+    def search_and_link_revoke
+      conn = Faraday.new(BASE_URL + "/revoke")
+
+      body = {
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        token: @user.orcid_search_and_link_access_token,
+      }
+
+      response = conn.post do |req|
+        req.body = body
+      end
+
+      if response.success?
+        @user.update(orcid_search_and_link_access_token: nil,
+                     orcid_search_and_link_refresh_token: nil,
+                     orcid_search_and_link_expires_at: nil)
+      else
+        puts "Error revoking tokens: #{response.status} - #{response.body}"
+        nil
+      end
+
+      redirect_to stored_location_for(:user) || setting_path("me")
+    end
+
+
+    def load_user
+      if user_signed_in?
+        @user = current_user
+      else
+        fail CanCan::AccessDenied.new("Please sign in first.", :read, User)
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,6 +75,9 @@ class User < ApplicationRecord
       indexes :role_id,       type: :keyword
       indexes :role_name,     type: :keyword
       indexes :orcid_token,   type: :keyword
+      indexes :orcid_search_and_link_access_token,   type: :keyword
+      indexes :orcid_search_and_link_refresh_token,   type: :keyword
+      indexes :orcid_search_and_link_expires_at,   type: :date
       indexes :created,       type: :date
       indexes :updated,       type: :date
       indexes :orcid_expires_at, type: :date
@@ -106,6 +109,9 @@ class User < ApplicationRecord
       "is_active" => is_active,
       "orcid_token" => orcid_token,
       "orcid_expires_at" => orcid_expires_at,
+      "orcid_search_and_link_access_token" => orcid_search_and_link_access_token,
+      "orcid_search_and_link_refresh_token" => orcid_search_and_link_refresh_token,
+      "orcid_search_and_link_expires_at" => orcid_search_and_link_expires_at,
       "claims_count" => claims_count,
     }
   end

--- a/app/views/settings/_show.html.erb
+++ b/app/views/settings/_show.html.erb
@@ -75,6 +75,20 @@
         </div>
         <div class="panel-body">
           <dl class="dl-horizontal">
+            <dt>Link Works to ORCID</dt>
+            <dd>
+              <% if @user.orcid_search_and_link_access_token %>
+                <p>Revoke access for DataCite to link DataCite DOIs to you ORCID record using the "Add to ORCID Record" button in DataCite Commons</p>
+                <%= link_to "<img id=\"orcid-logo\" src=\"#{ENV["CDN_URL"]}/images/orcid.png\" alt=\"ORCID icon\"/>&nbsp;Click to Disable".html_safe, :orcid_search_and_link_revoke, method: :get, :id => "orcid-search-and-link-disable", class: 'btn btn-social btn-orcid btn-fill' %>
+              <% else %>
+                <p>Allow DataCite to link DataCite DOIs to you ORCID record using the "Add to ORCID Record" button in DataCite Commons</p>
+                <%= link_to "<img id=\"orcid-logo\" src=\"#{ENV["CDN_URL"]}/images/orcid.png\" alt=\"ORCID icon\"/>&nbsp;Click to Enable".html_safe, :orcid_search_and_link_auth, method: :get, :id => "orcid-search-and-link-enable", class: 'btn btn-social btn-orcid btn-fill' %>
+              <% end %>
+            </dd>
+          </dl>
+        </div>
+        <div class="panel-body">
+          <dl class="dl-horizontal">
             <dt>ORCID Permissions</dt>
             <dd>
               <% if Time.zone.now < @user.orcid_expires_at %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
     get "link_orcid", to: "users/sessions#link_orcid", as: :link_orcid_session
 
     get "auth", to: "users/omniauth_callbacks#forward"
+
+    get "orcid/search_and_link/auth", to: "users/orcid#search_and_link_auth", as: :orcid_search_and_link_auth
+    get "orcid/search_and_link/callback", to: "users/orcid#search_and_link_callback", as: :orcid_search_and_link_callback
+    get "orcid/search_and_link/revoke", to: "users/orcid#search_and_link_revoke", as: :orcid_search_and_link_revoke
   end
 
   # enable feature flags api

--- a/db/migrate/20250603132805_add_orcid_search_and_link_tokens_to_users.rb
+++ b/db/migrate/20250603132805_add_orcid_search_and_link_tokens_to_users.rb
@@ -1,0 +1,6 @@
+class AddOrcidSearchAndLinkTokensToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :orcid_search_and_link_access_token, :string
+    add_column :users, :orcid_search_and_link_refresh_token, :string
+  end
+end

--- a/db/migrate/20250603133258_add_orcid_search_and_link_expires_at_to_users.rb
+++ b/db/migrate/20250603133258_add_orcid_search_and_link_expires_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddOrcidSearchAndLinkExpiresAtToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :orcid_search_and_link_expires_at, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_08_143711) do
-  create_table "claims", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+ActiveRecord::Schema[7.1].define(version: 2025_06_03_133258) do
+  create_table "claims", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "uuid", limit: 191
     t.string "doi", limit: 191
     t.integer "state_number", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "orcid", limit: 191
     t.string "source_id", limit: 191
-    t.datetime "claimed_at"
+    t.datetime "claimed_at", precision: nil
     t.text "error_messages"
     t.string "claim_action", limit: 191, default: "create"
     t.integer "put_code"
@@ -33,15 +31,15 @@ ActiveRecord::Schema.define(version: 2024_04_08_143711) do
     t.index ["updated_at", "aasm_state"], name: "index_claims_on_updated_state"
   end
 
-  create_table "funders", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "funders", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "fundref_id"
     t.string "name"
     t.string "replaced"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "members", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "members", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "title", null: false
     t.text "description"
@@ -53,23 +51,23 @@ ActiveRecord::Schema.define(version: 2024_04_08_143711) do
     t.string "email"
     t.string "website"
     t.string "phone"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "image"
     t.string "institution_type", limit: 191
     t.index ["institution_type"], name: "index_member_institution_type"
     t.index ["name"], name: "index_members_on_name"
   end
 
-  create_table "status", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "status", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "uuid", limit: 191
     t.integer "users_count", default: 0
     t.integer "users_new_count", default: 0
     t.bigint "db_size", default: 0
     t.string "version"
     t.string "current_version"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "claims_search_count", default: 0
     t.integer "claims_search_new_count", default: 0
     t.integer "claims_auto_count", default: 0
@@ -80,7 +78,7 @@ ActiveRecord::Schema.define(version: 2024_04_08_143711) do
     t.index ["created_at"], name: "index_status_created_at"
   end
 
-  create_table "users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 191
     t.string "family_name", limit: 191
     t.string "given_names", limit: 191
@@ -90,13 +88,13 @@ ActiveRecord::Schema.define(version: 2024_04_08_143711) do
     t.string "authentication_token", limit: 191
     t.string "role_id", default: "user"
     t.boolean "auto_update", default: true
-    t.datetime "expires_at", default: "1970-01-01 00:00:00", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "expires_at", precision: nil, default: "1970-01-01 00:00:00", null: false
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "other_names"
     t.string "confirmation_token", limit: 191
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
+    t.datetime "confirmed_at", precision: nil
+    t.datetime "confirmation_sent_at", precision: nil
     t.string "unconfirmed_email"
     t.string "github", limit: 191
     t.string "github_uid", limit: 191
@@ -109,7 +107,10 @@ ActiveRecord::Schema.define(version: 2024_04_08_143711) do
     t.boolean "beta_tester", default: false
     t.string "organization", limit: 191
     t.string "orcid_token", limit: 191
-    t.datetime "orcid_expires_at", default: "1970-01-01 00:00:00", null: false
+    t.datetime "orcid_expires_at", precision: nil, default: "1970-01-01 00:00:00", null: false
+    t.string "orcid_search_and_link_access_token"
+    t.string "orcid_search_and_link_refresh_token"
+    t.string "orcid_search_and_link_expires_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["family_name", "given_names"], name: "index_users_on_family_name_and_given_names"
     t.index ["github"], name: "index_users_on_github", unique: true
@@ -117,4 +118,5 @@ ActiveRecord::Schema.define(version: 2024_04_08_143711) do
     t.index ["is_public"], name: "index_users_on_is_public"
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
+
 end

--- a/spec/factories/default.rb
+++ b/spec/factories/default.rb
@@ -25,11 +25,13 @@ FactoryBot.define do
     factory :valid_user do
       uid { "0000-0001-6528-2027" }
       orcid_token { ENV["ORCID_TOKEN"] }
+      orcid_search_and_link_access_token { "TEST_SEARCH_AND_LINK_TOKEN" }
     end
 
     factory :invalid_user do
       uid { "0000-0001-6528-2027" }
       orcid_token { nil }
+      orcid_search_and_link_access_token { nil }
     end
 
     initialize_with { User.where(uid: uid).first_or_initialize }

--- a/spec/fixtures/vcr_cassettes/Claim/collect_data_with_source_orcid_search/expired_token.yml
+++ b/spec/fixtures/vcr_cassettes/Claim/collect_data_with_source_orcid_search/expired_token.yml
@@ -1,0 +1,299 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/1x4x-9056?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:05:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - 11141a19-afb8-4d76-a113-b494342791ef
+      Etag:
+      - W/"07b2805274bbc57630b9f044a27b0a5d"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.039572'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAKwiQmgAA7RYWW/iyhL+K0e8XOnOkHjBMzjSfQATwAwQYryAR/PgpWMa2svxgjGj/Pdb7YUlITNzj3Qjodjl2rrqq+qu/tlyrdRqPfxsYbf10GKZO7bTETr37KFzaIuM8KX1uZUWEYJvbogTeLPSNMZ2lqKESgHxI7EoRi/4cPEVaEn2UtMuGLGLghS/YBSDyu8/wARJURxYKZLffnFiZKVh+fazFVg+9WuIggDFn/+aWXGKA9BH6Wrl8wIkw8AiQPXwHgXzSuTE+mL5mBTzS0W1gmvTP1uJs0E+0mK63E2aRsnD/X0YO9i9C2PvncwtpnsG/trw49tshxXbXIcR3gkuSzMg/qRI8qD1SqMBISPYSnEY0CBQUopTgiq/ykfgl8KQ/DV4kv+VlEJRZhOcbEpPBpBhCacIjDlhkFqYrhJyV+d1iWKMkqs8VEkTOny3cTq5ZqjDC/Zar7Uxp/RwjSyQ5hj2C022vUVOWseveqlwBEKXlBdIahYjt/SculgCLGySDgitF0ufgJ+qb7Ncm6Xxo7TaHTlJMqrl8285JYqj2iCxAi+zPCAHGSEV3Etsx4D3h5ayUFQQtrGdIopcCh2HlMGEmEZx6JyJ7W2YxRXcSrxYT4ANiLCzCYkVk6J3ko1RAqxO40+fhN4iTACU3puPIwTZAo0PLRUdUhrtGBHq+1uAlmTIwCkWC3Dq6aV1Q+CD9P7C7A0lVxB4Z15BLyhGgYOSDxxoyiPP87ucL+tjEYd7gFh8v0wLgu41Rf6FXU2Z/iO7tBnxX9n7OlN3URigO4ZlBU7gf7fMH+fvKfJrdCb4iOrHlzD2rbR+2UNiypJtsXcM1Yy9TZpMcZLWqEaJE+OI+l5LeCichlUZNQqzwAVIXCyqJB98mpjFQOzYRu65vl44HNnbWwbPlp1cxn1i+/O9OSKZeWSwriujqerhxbHzbTGeEIcTWcefE3m8Se2RcHwKNkdLZbA1VhhnEO6nvMu7hcDPCmHv+M5+tu3ls6W4VrWDuuY2xDYeU8sQju5omK05DTd6FstJ6I6V/Al3wfaQWRvzyB1pmc1Pgik/31ojPV0vxdhcTTLTyNO5JHtoPI+egvqbdtivuSFjGWL2v+vqn/gdbh6aBruZ+soGfNxaK4VMfbEwCzE1V8pmyqXE8QViSwwz5VgCPLs1pUMcTEn+JOGetxiRnWkI4IsZmSvZswyF2IESmT4hDlEEZ6SJ8k5ZLJfyp5nay2bqMzNXn/cz3WMMiRFmA41bSGJkjvTMHRHfMvRi4YWePDhsHV8Hv8TCgXzIUu+KVvJQmtTrrvkJAb/2zk7Y2Ibm2f4wNfXaNukTJ5jvgZbIW2EEvmbgZyI/shsH/LS3+f6NfLmu2l5grUxi13TVGBbgYwb+XtEv+P21wUb2mDzBf7LYAQ/EzwEbJvhkGQdBpb6p9XokGj+qQ59crl++QdOqXBHI90LbzSew6Xl1/oiuTyYNDpwj4JITizVHdlUu5U8lXsezL9NCBJzOI1Oq8ToAvEpMDv+PU/WRmam7dLZ9zudqvi9jqF3ltllnd8rNC9MYMjZfY0AS3+aqC34z9kg/NnlajBXA5QFiArngck95FCcTftad8jW9zHm+v5IbHHLXmCTWCtYJ9hWKb63EN8j12bV/iByoM2db2XTGOrZHZAu5jGxOMMHHYrGV85m6PvE3dWMY+uYk5+tHm9chZrqGVn2o93Pt62OSm5oLeYTvRg54UggaP+PFbpLYnPts83PQJwQQg8JczffuarKtsVfFZjwHuxFZ88pFLBra8ydzJEYge4R1/m0ac+YmD43tWIeYP8M6zvQ69ifZJva0D5ir2Slf5fuyT2u3Wg/0sOVqDnL6Tt52itngkYP8F/BjQV/Jd/JjRHuD5pU6mpraVfkHf3Ad33SmyvCDvHAl/y9t66vqnfaQp0DBa8BbyVfVRa3jhAGwdaDvu+VlbwnO64P8JaW+x+tedJs+KXMM9fKoMjtMc22PKkxcxOZ5vZowKrfGf4SF7WM+3WrM7Oida2o8P5aYuOX79tTPbn/H/dv0pp8SfalKp/VRrDdrWpqGCT1bh/1GP0K/O/eEN3uVNp7sXR/ispL3Gq8I9kjbl33k/+VztQf8gc+dw0yC39E5TLmI1lMGsc6ckZiZsGfPAKOzrfa72EKdVHk1DeWqj5760+ks0DlMt5TfpPsE+NWp9zUF8j4vrFW/xMbFHgQxm0O/Izno3Nu4f/1+Wu8QO7wCOJkzkIeJjXuHJ3XXkYew9mVfKvfj1eQ41Q4E6mNrc3AGMZ49d7SB/gO2fcZbc+Lelvq6tiNHWfJK+W/LnPJsXKkfOUX9bayE69Uz1KiYdULJhG+w7w8zk9MyeegSeZTCecBp5EDmcKS4hr4CMRS21K5ldGrb9MwgQo4mCVr2E3omcPwhA3kAPcMCfN2bAcQb90Hnc+1j7kHP3pTnqKLP2AXIGUIsU4xJvXDJHQjVb4KPNJdTqUd7DvNt2d/Y/rNnG8OY9lAZer8MPjqUxtOzBJtDfz1asAeAXaoXcijsprhD9+DruG9PveNd3q56s9r5D5wxs5hcHK1tGCru6HhPB5XyhO3AkNimc/x9PQvCKVejMvRU6aPUotx6c3DtfG3GmBOp1A2qr7RWPPc7mNkRaZdjfjlH0MnOsmOYDIdwMKbzY9JzUhjDWw9pnCFgS6sp7QUHrmXXc5GVUEPVKLbHKJfCLIAjM1O9JU9wrlYxHZHLQ3SYByS03DNTQ3nDGDdH6JqTLce38qx9lm0ob2QjGKTOTFE5Vp3V1Of8CzcrwomHqa8tkFsNpF06kPKMyn55ELoPfPcORjCzXLoHwwGKP+ATG75mtK/Z6A1KFrkn/RzMc0Kb66rMlweGeRDYSq4ZHOnyNjgqB1yHYEQ9/Hl9CXRKbvNwvgOqJJLWK53663HtQ/mzWMNaCfrIxdY7qV9dPVUSr68XeUzOCr5faPjFaHd5jfX64/Ui3ReqKJ1m+BYNhulbNt/N0e8M1Yh4q/MElCs6XSUOHJK5NKHf/zwnb6/m6uux5vbnLwVFYYLTsL7tSQrfDmm7GPTUniSrj3fNA3wsmmsc9uI2rromqyrzYnptSOd7lO8tVF6uxS16n1O6V4/REYpx6EJHoFckbuhbmEal9e+rNvX5BXvJxorRnRP6ZWHwVXQqO2GEAjek/lXvOEmCEkXwnzTEKMYU2S1W6Ajtr90uvf9BBDlpHAbYqT502iL7laeVUfbNSvCqVFlagsxXleUfOvxFCV7VG9tm+DYnqoz4AKXKCQ3Tdbe7VX//uIKgdSdhnOLMfyc6kD4Squ5jPygcCuJLwZqV3rA0LF9hXdwf8LC3eCiuf7z+FwAA//8DAIhCs+tuFgAA
+  recorded_at: Thu, 05 Jun 2025 23:05:15 GMT
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/1x4x-9056?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:05:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - d5f83607-a04d-4320-8a2e-977efeb6f552
+      Etag:
+      - W/"07b2805274bbc57630b9f044a27b0a5d"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.034096'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAKwiQmgAA7RYWW/iyhL+K0e8XOnOkHjBMzjSfQATwAwQYryAR/PgpWMa2svxgjGj/Pdb7YUlITNzj3Qjodjl2rrqq+qu/tlyrdRqPfxsYbf10GKZO7bTETr37KFzaIuM8KX1uZUWEYJvbogTeLPSNMZ2lqKESgHxI7EoRi/4cPEVaEn2UtMuGLGLghS/YBSDyu8/wARJURxYKZLffnFiZKVh+fazFVg+9WuIggDFn/+aWXGKA9BH6Wrl8wIkw8AiQPXwHgXzSuTE+mL5mBTzS0W1gmvTP1uJs0E+0mK63E2aRsnD/X0YO9i9C2PvncwtpnsG/trw49tshxXbXIcR3gkuSzMg/qRI8qD1SqMBISPYSnEY0CBQUopTgiq/ykfgl8KQ/DV4kv+VlEJRZhOcbEpPBpBhCacIjDlhkFqYrhJyV+d1iWKMkqs8VEkTOny3cTq5ZqjDC/Zar7Uxp/RwjSyQ5hj2C022vUVOWseveqlwBEKXlBdIahYjt/SculgCLGySDgitF0ufgJ+qb7Ncm6Xxo7TaHTlJMqrl8285JYqj2iCxAi+zPCAHGSEV3Etsx4D3h5ayUFQQtrGdIopcCh2HlMGEmEZx6JyJ7W2YxRXcSrxYT4ANiLCzCYkVk6J3ko1RAqxO40+fhN4iTACU3puPIwTZAo0PLRUdUhrtGBHq+1uAlmTIwCkWC3Dq6aV1Q+CD9P7C7A0lVxB4Z15BLyhGgYOSDxxoyiPP87ucL+tjEYd7gFh8v0wLgu41Rf6FXU2Z/iO7tBnxX9n7OlN3URigO4ZlBU7gf7fMH+fvKfJrdCb4iOrHlzD2rbR+2UNiypJtsXcM1Yy9TZpMcZLWqEaJE+OI+l5LeCichlUZNQqzwAVIXCyqJB98mpjFQOzYRu65vl44HNnbWwbPlp1cxn1i+/O9OSKZeWSwriujqerhxbHzbTGeEIcTWcefE3m8Se2RcHwKNkdLZbA1VhhnEO6nvMu7hcDPCmHv+M5+tu3ls6W4VrWDuuY2xDYeU8sQju5omK05DTd6FstJ6I6V/Al3wfaQWRvzyB1pmc1Pgik/31ojPV0vxdhcTTLTyNO5JHtoPI+egvqbdtivuSFjGWL2v+vqn/gdbh6aBruZ+soGfNxaK4VMfbEwCzE1V8pmyqXE8QViSwwz5VgCPLs1pUMcTEn+JOGetxiRnWkI4IsZmSvZswyF2IESmT4hDlEEZ6SJ8k5ZLJfyp5nay2bqMzNXn/cz3WMMiRFmA41bSGJkjvTMHRHfMvRi4YWePDhsHV8Hv8TCgXzIUu+KVvJQmtTrrvkJAb/2zk7Y2Ibm2f4wNfXaNukTJ5jvgZbIW2EEvmbgZyI/shsH/LS3+f6NfLmu2l5grUxi13TVGBbgYwb+XtEv+P21wUb2mDzBf7LYAQ/EzwEbJvhkGQdBpb6p9XokGj+qQ59crl++QdOqXBHI90LbzSew6Xl1/oiuTyYNDpwj4JITizVHdlUu5U8lXsezL9NCBJzOI1Oq8ToAvEpMDv+PU/WRmam7dLZ9zudqvi9jqF3ltllnd8rNC9MYMjZfY0AS3+aqC34z9kg/NnlajBXA5QFiArngck95FCcTftad8jW9zHm+v5IbHHLXmCTWCtYJ9hWKb63EN8j12bV/iByoM2db2XTGOrZHZAu5jGxOMMHHYrGV85m6PvE3dWMY+uYk5+tHm9chZrqGVn2o93Pt62OSm5oLeYTvRg54UggaP+PFbpLYnPts83PQJwQQg8JczffuarKtsVfFZjwHuxFZ88pFLBra8ydzJEYge4R1/m0ac+YmD43tWIeYP8M6zvQ69ifZJva0D5ir2Slf5fuyT2u3Wg/0sOVqDnL6Tt52itngkYP8F/BjQV/Jd/JjRHuD5pU6mpraVfkHf3Ad33SmyvCDvHAl/y9t66vqnfaQp0DBa8BbyVfVRa3jhAGwdaDvu+VlbwnO64P8JaW+x+tedJs+KXMM9fKoMjtMc22PKkxcxOZ5vZowKrfGf4SF7WM+3WrM7Oida2o8P5aYuOX79tTPbn/H/dv0pp8SfalKp/VRrDdrWpqGCT1bh/1GP0K/O/eEN3uVNp7sXR/ispL3Gq8I9kjbl33k/+VztQf8gc+dw0yC39E5TLmI1lMGsc6ckZiZsGfPAKOzrfa72EKdVHk1DeWqj5760+ks0DlMt5TfpPsE+NWp9zUF8j4vrFW/xMbFHgQxm0O/Izno3Nu4f/1+Wu8QO7wCOJkzkIeJjXuHJ3XXkYew9mVfKvfj1eQ41Q4E6mNrc3AGMZ49d7SB/gO2fcZbc+Lelvq6tiNHWfJK+W/LnPJsXKkfOUX9bayE69Uz1KiYdULJhG+w7w8zk9MyeegSeZTCecBp5EDmcKS4hr4CMRS21K5ldGrb9MwgQo4mCVr2E3omcPwhA3kAPcMCfN2bAcQb90Hnc+1j7kHP3pTnqKLP2AXIGUIsU4xJvXDJHQjVb4KPNJdTqUd7DvNt2d/Y/rNnG8OY9lAZer8MPjqUxtOzBJtDfz1asAeAXaoXcijsprhD9+DruG9PveNd3q56s9r5D5wxs5hcHK1tGCru6HhPB5XyhO3AkNimc/x9PQvCKVejMvRU6aPUotx6c3DtfG3GmBOp1A2qr7RWPPc7mNkRaZdjfjlH0MnOsmOYDIdwMKbzY9JzUhjDWw9pnCFgS6sp7QUHrmXXc5GVUEPVKLbHKJfCLIAjM1O9JU9wrlYxHZHLQ3SYByS03DNTQ3nDGDdH6JqTLce38qx9lm0ob2QjGKTOTFE5Vp3V1Of8CzcrwomHqa8tkFsNpF06kPKMyn55ELoPfPcORjCzXLoHwwGKP+ATG75mtK/Z6A1KFrkn/RzMc0Kb66rMlweGeRDYSq4ZHOnyNjgqB1yHYEQ9/Hl9CXRKbvNwvgOqJJLWK53663HtQ/mzWMNaCfrIxdY7qV9dPVUSr68XeUzOCr5faPjFaHd5jfX64/Ui3ReqKJ1m+BYNhulbNt/N0e8M1Yh4q/MElCs6XSUOHJK5NKHf/zwnb6/m6uux5vbnLwVFYYLTsL7tSQrfDmm7GPTUniSrj3fNA3wsmmsc9uI2rromqyrzYnptSOd7lO8tVF6uxS16n1O6V4/REYpx6EJHoFckbuhbmEal9e+rNvX5BXvJxorRnRP6ZWHwVXQqO2GEAjek/lXvOEmCEkXwnzTEKMYU2S1W6Ajtr90uvf9BBDlpHAbYqT502iL7laeVUfbNSvCqVFlagsxXleUfOvxFCV7VG9tm+DYnqoz4AKXKCQ3Tdbe7VX//uIKgdSdhnOLMfyc6kD4Squ5jPygcCuJLwZqV3rA0LF9hXdwf8LC3eCiuf7z+FwAA//8DAIhCs+tuFgAA
+  recorded_at: Thu, 05 Jun 2025 23:05:16 GMT
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/1x4x-9056?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:05:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - 2fb0f010-b5a7-406b-bf97-b10850a5e17c
+      Etag:
+      - W/"f3a84733999c13c0d05261115f78bf38"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.028995'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAK0iQmgAA7RYWW/iyhL+K0e8XOnOkHjBMzjSfQATwAwQYryAR/PgpWMa2svxgjGj/Pdb7YUlITNzj3Qjodjl2rrqq+qu/tlyrdRqPfxsYbf10GKZO7bTETr37KFzaIuM8KX1uZUWEYJvbogTeLPSNMZ2lqKESgHxI7EoRi/4cPEVaEn2UtMuGLGLghS/YBSDyu8/wARJURxYKZLffnFiZKVh+fazFVg+9WuIggDFn/+aWXGKA9BH6Wrl8wIkw8AiQPXwHgXzSuTE+mL5mBTzS0W1gmvTP1uJs0E+0mK63E2aRsnD/X0YO9i9C2PvncwtpnsG/trw49tshxXbXIcR3gkuSzMg/qRI8qD1SqMBISPYSnEY0CBQUopTgiq/ykfgl8KQ/DV4kv+VlEJRZhOcbEpPBpBhCacIjDlhkFqYrhJyV+d1iWKMkqs8VEkTOny3cTq5ZqjDC/Zar7Uxp/RwjSyQ5hj2C022vUVOWseveqlwBEKXlBdIahYjt/SculgCLGySDgitF0ufgJ+qb7Ncm6Xxo7TaHTlJMqrl8285JYqj2iCxAi+zPCAHGSEV3Etsx4D3h5ayUFQQtrGdIopcCh2HlMGEmEZx6JyJ7W2YxRXcSrxYT4ANiLCzCYkVk6J3ko1RAqxO40+fhN4iTACU3puPIwTZAo0PLRUdUhrtGBHq+1uAlmTIwCkWC3Dq6aV1Q+CD9P7C7A0lVxB4Z15BLyhGgYOSDxxoyiPP87ucL+tjEYd7gFh8v0wLgu41Rf6FXU2Z/iO7tBnxX9n7OlN3URigO4ZlBU7gf7fMH+fvKfJrdCb4iOrHlzD2rbR+2UNiypJtsXcM1Yy9TZpMcZLWqEaJE+OI+l5LeCichlUZNQqzwAVIXCyqJB98mpjFQOzYRu65vl44HNnbWwbPlp1cxn1i+/O9OSKZeWSwriujqerhxbHzbTGeEIcTWcefE3m8Se2RcHwKNkdLZbA1VhhnEO6nvMu7hcDPCmHv+M5+tu3ls6W4VrWDuuY2xDYeU8sQju5omK05DTd6FstJ6I6V/Al3wfaQWRvzyB1pmc1Pgik/31ojPV0vxdhcTTLTyNO5JHtoPI+egvqbdtivuSFjGWL2v+vqn/gdbh6aBruZ+soGfNxaK4VMfbEwCzE1V8pmyqXE8QViSwwz5VgCPLs1pUMcTEn+JOGetxiRnWkI4IsZmSvZswyF2IESmT4hDlEEZ6SJ8k5ZLJfyp5nay2bqMzNXn/cz3WMMiRFmA41bSGJkjvTMHRHfMvRi4YWePDhsHV8Hv8TCgXzIUu+KVvJQmtTrrvkJAb/2zk7Y2Ibm2f4wNfXaNukTJ5jvgZbIW2EEvmbgZyI/shsH/LS3+f6NfLmu2l5grUxi13TVGBbgYwb+XtEv+P21wUb2mDzBf7LYAQ/EzwEbJvhkGQdBpb6p9XokGj+qQ59crl++QdOqXBHI90LbzSew6Xl1/oiuTyYNDpwj4JITizVHdlUu5U8lXsezL9NCBJzOI1Oq8ToAvEpMDv+PU/WRmam7dLZ9zudqvi9jqF3ltllnd8rNC9MYMjZfY0AS3+aqC34z9kg/NnlajBXA5QFiArngck95FCcTftad8jW9zHm+v5IbHHLXmCTWCtYJ9hWKb63EN8j12bV/iByoM2db2XTGOrZHZAu5jGxOMMHHYrGV85m6PvE3dWMY+uYk5+tHm9chZrqGVn2o93Pt62OSm5oLeYTvRg54UggaP+PFbpLYnPts83PQJwQQg8JczffuarKtsVfFZjwHuxFZ88pFLBra8ydzJEYge4R1/m0ac+YmD43tWIeYP8M6zvQ69ifZJva0D5ir2Slf5fuyT2u3Wg/0sOVqDnL6Tt52itngkYP8F/BjQV/Jd/JjRHuD5pU6mpraVfkHf3Ad33SmyvCDvHAl/y9t66vqnfaQp0DBa8BbyVfVRa3jhAGwdaDvu+VlbwnO64P8JaW+x+tedJs+KXMM9fKoMjtMc22PKkxcxOZ5vZowKrfGf4SF7WM+3WrM7Oida2o8P5aYuOX79tTPbn/H/dv0pp8SfalKp/VRrDdrWpqGCT1bh/1GP0K/O/eEN3uVNp7sXR/ispL3Gq8I9kjbl33k/+VztQf8gc+dw0yC39E5TLmI1lMGsc6ckZiZsGfPAKOzrfa72EKdVHk1DeWqj5760+ks0DlMt5TfpPsE+NWp9zUF8j4vrFW/xMbFHgQxm0O/Izno3Nu4f/1+Wu8QO7wCOJkzkIeJjXuHJ3XXkYew9mVfKvfj1eQ41Q4E6mNrc3AGMZ49d7SB/gO2fcZbc+Lelvq6tiNHWfJK+W/LnPJsXKkfOUX9bayE69Uz1KiYdULJhG+w7w8zk9MyeegSeZTCecBp5EDmcKS4hr4CMRS21K5ldGrb9MwgQo4mCVr2E3omcPwhA3kAPcMCfN2bAcQb90Hnc+1j7kHP3pTnqKLP2AXIGUIsU4xJvXDJHQjVb4KPNJdTqUd7DvNt2d/Y/rNnG8OY9lAZer8MPjqUxtOzBJtDfz1asAeAXaoXcijsprhD9+DruG9PveNd3q56s9r5D5wxs5hcHK1tGCru6HhPB5XyhO3AkNimc/x9PQvCKVejMvRU6aPUotx6c3DtfG3GmBOp1A2qr7RWPPc7mNkRaZdjfjlH0MnOsmOYDIdwMKbzY9JzUhjDWw9pnCFgS6sp7QUHrmXXc5GVUEPVKLbHKJfCLIAjM1O9JU9wrlYxHZHLQ3SYByS03DNTQ3nDGDdH6JqTLce38qx9lm0ob2QjGKTOTFE5Vp3V1Of8CzcrwomHqa8tkFsNpF06kPKMyn55ELoPfPcORjCzXLoHwwGKP+ATG75mtK/Z6A1KFrkn/RzMc0Kb66rMlweGeRDYSq4ZHOnyNjgqB1yHYEQ9/Hl9CXRKbvNwvgOqJJLWK53663HtQ/mzWMNaCfrIxdY7qV9dPVUSr68XeUzOCr5faPjFaHd5jfX64/Ui3ReqKJ1m+BYNhulbNt/N0e8M1Yh4q/MElCs6XSUOHJK5NKHf/zwnb6/m6uux5vbnLwVFYYLTsL7tSQrfDmm7GPTUniSrj3fNA3wsmmsc9uI2rromqyrzYnptSOd7lO8tVF6uxS16n1O6V4/REYpx6EJHoFckbuhbmEal9e+rNvX5BXvJxorRnRP6ZWHwVXQqO2GEAjek/lXvOEmCEkXwnzTEKMYU2S1W6Ajtr90uvf9BBDlpHAbYqT502iL7laeVUfbNSvCqVFlagsxXleUfOvxFCV7VG9tm+DYnqoz4AKXKCQ3Tdbe7VX//uIKgdSdhnOLMfyc6kD4Squ5jPygcCuJLwZqV3rA0LF9hXdwf8LC3eCiuf7z+FwAA//8DAIhCs+tuFgAA
+  recorded_at: Thu, 05 Jun 2025 23:05:17 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.orcid.org/v3.0/0000-0001-6528-2027/work
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <work:work xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:common="http://www.orcid.org/ns/common" xmlns:work="http://www.orcid.org/ns/work" visibility="public" xsi:schemaLocation="http://www.orcid.org/ns/work ../work-3.0.xsd">
+          <work:title>
+            <common:title>Cool DOI's</common:title>
+          </work:title>
+          <work:journal-title>DataCite</work:journal-title>
+          <work:short-description>In 1998 Tim Berners-Lee coined the term cool URIs (1998), that is URIs that don’t change. We know that URLs referenced in the scholarly literature are often not cool, leading to link rot (Klein et al., 2014) and making it hard or impossible to find...</work:short-description>
+          <work:type>other</work:type>
+          <common:publication-date>
+            <common:year>2016</common:year>
+            <common:month>12</common:month>
+            <common:day>15</common:day>
+          </common:publication-date>
+          <common:external-ids>
+            <common:external-id>
+              <common:external-id-type>doi</common:external-id-type>
+              <common:external-id-value>10.14454/1X4X-9056</common:external-id-value>
+              <common:external-id-relationship>self</common:external-id-relationship>
+            </common:external-id>
+          </common:external-ids>
+          <work:contributors>
+            <work:contributor>
+              <common:contributor-orcid>
+                <common:uri>https://orcid.org/0000-0003-1419-2405</common:uri>
+                <common:path>0000-0003-1419-2405</common:path>
+                <common:host>orcid.org</common:host>
+              </common:contributor-orcid>
+              <work:credit-name>Martin Fenner</work:credit-name>
+            </work:contributor>
+          </work:contributors>
+        </work:work>
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Content-Type:
+      - application/vnd.orcid+xml
+      Authorization:
+      - Bearer TEST_SEARCH_AND_LINK_TOKEN
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:05:17 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 94b3505b6b90e843-DFW
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-store
+      Pragma:
+      - no-cache
+      Www-Authenticate:
+      - 'Bearer realm="ORCID T2 API", error="invalid_token", error_description="Invalid
+        access token: TEST_SEARCH_AND_LINK_TOKEN"'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Content-Encoding:
+      - gzip
+      X-Target:
+      - reg-sbox-mapi-use2-a1
+      X-Via:
+      - a1
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKrmUlBQSi0qyi9SUrBSUMrMK0vMyUyJL8nPTs1T0oFLxqekFicXZRaUZObngRV6QhQqJCYnpxYXK4DVWymEuAaHxAe7OgY5e8Q7+rnE+3j6eceH+Hu7+ilx1QIAAAD//wMAZy+8J2sAAAA=
+  recorded_at: Thu, 05 Jun 2025 23:05:17 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Claim/collect_data_with_source_orcid_update/expired_token.yml
+++ b/spec/fixtures/vcr_cassettes/Claim/collect_data_with_source_orcid_update/expired_token.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/1x4x-9056?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:04:36 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - 7414ab02-6e2b-4add-b88a-872567e31b69
+      Etag:
+      - W/"31eb11e699648ce1bbfcbb8167f2741a"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.041709'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAIQiQmgAA7RYWW/iyhL+K0e8XOnOkHjBMzjSfQATwAwQYryAR/PgpWMa2svxgjGj/Pdb7YUlITNzj3Qjodjl2rrqq+qu/tlyrdRqPfxsYbf10GKZO7bTETr37KFzaIuM8KX1uZUWEYJvbogTeLPSNMZ2lqKESgHxI7EoRi/4cPEVaEn2UtMuGLGLghS/YBSDyu8/wARJURxYKZLffnFiZKVh+fazFVg+9WuIggDFn/+aWXGKA9BH6Wrl8wIkw8AiQPXwHgXzSuTE+mL5mBTzS0W1gmvTP1uJs0E+0mK63E2aRsnD/X0YO9i9C2PvncwtpnsG/trw49tshxXbXIcR3gkuSzMg/qRI8qD1SqMBISPYSnEY0CBQUopTgiq/ykfgl8KQ/DV4kv+VlEJRZhOcbEpPBpBhCacIjDlhkFqYrhJyV+d1iWKMkqs8VEkTOny3cTq5ZqjDC/Zar7Uxp/RwjSyQ5hj2C022vUVOWseveqlwBEKXlBdIahYjt/SculgCLGySDgitF0ufgJ+qb7Ncm6Xxo7TaHTlJMqrl8285JYqj2iCxAi+zPCAHGSEV3Etsx4D3h5ayUFQQtrGdIopcCh2HlMGEmEZx6JyJ7W2YxRXcSrxYT4ANiLCzCYkVk6J3ko1RAqxO40+fhN4iTACU3puPIwTZAo0PLRUdUhrtGBHq+1uAlmTIwCkWC3Dq6aV1Q+CD9P7C7A0lVxB4Z15BLyhGgYOSDxxoyiPP87ucL+tjEYd7gFh8v0wLgu41Rf6FXU2Z/iO7tBnxX9n7OlN3URigO4ZlBU7gf7fMH+fvKfJrdCb4iOrHlzD2rbR+2UNiypJtsXcM1Yy9TZpMcZLWqEaJE+OI+l5LeCichlUZNQqzwAVIXCyqJB98mpjFQOzYRu65vl44HNnbWwbPlp1cxn1i+/O9OSKZeWSwriujqerhxbHzbTGeEIcTWcefE3m8Se2RcHwKNkdLZbA1VhhnEO6nvMu7hcDPCmHv+M5+tu3ls6W4VrWDuuY2xDYeU8sQju5omK05DTd6FstJ6I6V/Al3wfaQWRvzyB1pmc1Pgik/31ojPV0vxdhcTTLTyNO5JHtoPI+egvqbdtivuSFjGWL2v+vqn/gdbh6aBruZ+soGfNxaK4VMfbEwCzE1V8pmyqXE8QViSwwz5VgCPLs1pUMcTEn+JOGetxiRnWkI4IsZmSvZswyF2IESmT4hDlEEZ6SJ8k5ZLJfyp5nay2bqMzNXn/cz3WMMiRFmA41bSGJkjvTMHRHfMvRi4YWePDhsHV8Hv8TCgXzIUu+KVvJQmtTrrvkJAb/2zk7Y2Ibm2f4wNfXaNukTJ5jvgZbIW2EEvmbgZyI/shsH/LS3+f6NfLmu2l5grUxi13TVGBbgYwb+XtEv+P21wUb2mDzBf7LYAQ/EzwEbJvhkGQdBpb6p9XokGj+qQ59crl++QdOqXBHI90LbzSew6Xl1/oiuTyYNDpwj4JITizVHdlUu5U8lXsezL9NCBJzOI1Oq8ToAvEpMDv+PU/WRmam7dLZ9zudqvi9jqF3ltllnd8rNC9MYMjZfY0AS3+aqC34z9kg/NnlajBXA5QFiArngck95FCcTftad8jW9zHm+v5IbHHLXmCTWCtYJ9hWKb63EN8j12bV/iByoM2db2XTGOrZHZAu5jGxOMMHHYrGV85m6PvE3dWMY+uYk5+tHm9chZrqGVn2o93Pt62OSm5oLeYTvRg54UggaP+PFbpLYnPts83PQJwQQg8JczffuarKtsVfFZjwHuxFZ88pFLBra8ydzJEYge4R1/m0ac+YmD43tWIeYP8M6zvQ69ifZJva0D5ir2Slf5fuyT2u3Wg/0sOVqDnL6Tt52itngkYP8F/BjQV/Jd/JjRHuD5pU6mpraVfkHf3Ad33SmyvCDvHAl/y9t66vqnfaQp0DBa8BbyVfVRa3jhAGwdaDvu+VlbwnO64P8JaW+x+tedJs+KXMM9fKoMjtMc22PKkxcxOZ5vZowKrfGf4SF7WM+3WrM7Oida2o8P5aYuOX79tTPbn/H/dv0pp8SfalKp/VRrDdrWpqGCT1bh/1GP0K/O/eEN3uVNp7sXR/ispL3Gq8I9kjbl33k/+VztQf8gc+dw0yC39E5TLmI1lMGsc6ckZiZsGfPAKOzrfa72EKdVHk1DeWqj5760+ks0DlMt5TfpPsE+NWp9zUF8j4vrFW/xMbFHgQxm0O/Izno3Nu4f/1+Wu8QO7wCOJkzkIeJjXuHJ3XXkYew9mVfKvfj1eQ41Q4E6mNrc3AGMZ49d7SB/gO2fcZbc+Lelvq6tiNHWfJK+W/LnPJsXKkfOUX9bayE69Uz1KiYdULJhG+w7w8zk9MyeegSeZTCecBp5EDmcKS4hr4CMRS21K5ldGrb9MwgQo4mCVr2E3omcPwhA3kAPcMCfN2bAcQb90Hnc+1j7kHP3pTnqKLP2AXIGUIsU4xJvXDJHQjVb4KPNJdTqUd7DvNt2d/Y/rNnG8OY9lAZer8MPjqUxtOzBJtDfz1asAeAXaoXcijsprhD9+DruG9PveNd3q56s9r5D5wxs5hcHK1tGCru6HhPB5XyhO3AkNimc/x9PQvCKVejMvRU6aPUotx6c3DtfG3GmBOp1A2qr7RWPPc7mNkRaZdjfjlH0MnOsmOYDIdwMKbzY9JzUhjDWw9pnCFgS6sp7QUHrmXXc5GVUEPVKLbHKJfCLIAjM1O9JU9wrlYxHZHLQ3SYByS03DNTQ3nDGDdH6JqTLce38qx9lm0ob2QjGKTOTFE5Vp3V1Of8CzcrwomHqa8tkFsNpF06kPKMyn55ELoPfPcORjCzXLoHwwGKP+ATG75mtK/Z6A1KFrkn/RzMc0Kb66rMlweGeRDYSq4ZHOnyNjgqB1yHYEQ9/Hl9CXRKbvNwvgOqJJLWK53663HtQ/mzWMNaCfrIxdY7qV9dPVUSr68XeUzOCr5faPjFaHd5jfX64/Ui3ReqKJ1m+BYNhulbNt/N0e8M1Yh4q/MElCs6XSUOHJK5NKHf/zwnb6/m6uux5vbnLwVFYYLTsL7tSQrfDmm7GPTUniSrj3fNA3wsmmsc9uI2rromqyrzYnptSOd7lO8tVF6uxS16n1O6V4/REYpx6EJHoFckbuhbmEal9e+rNvX5BXvJxorRnRP6ZWHwVXQqO2GEAjek/lXvOEmCEkXwnzTEKMYU2S1W6Ajtr90uvf9BBDlpHAbYqT502iL7laeVUfbNSvCqVFlagsxXleUfOvxFCV7VG9tm+DYnqoz4AKXKCQ3Tdbe7VX//uIKgdSdhnOLMfyc6kD4Squ5jPygcCuJLwZqV3rA0LF9hXdwf8LC3eCiuf7z+FwAA//8DAIhCs+tuFgAA
+  recorded_at: Thu, 05 Jun 2025 23:04:36 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Claim/process_data/no_permission_for_auto-update.yml
+++ b/spec/fixtures/vcr_cassettes/Claim/process_data/no_permission_for_auto-update.yml
@@ -1,0 +1,296 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/j6gr-cf48?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:03:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - 7980f42e-43d0-4f48-98e6-0ff39fa756c4
+      Etag:
+      - W/"48d3bab46a4b7f5d9d08e7e8dec0a24d"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.068123'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIADUiQmgAA5xX2W7jOhL9lQs9TrcTrR3LwH1w7MTLeIsiS7EaeZAoWqZDLZAob4H/fYpavCU9uDMBAlulU+SphcXjT8F3mSu0PgXiCy1BEu8kVdXU+/WvIG2gpdoUfgpsn2B458ckgyeXsZR4OcMZ9wLjn9ySFC/J7uIt2LJ8WdougcTHESNLglNY8vc7bEEZTiOX4cHtG5Ril8XF06cQuSHn9YyjCKc//xq7KSMRrMftZsl5Bp5x5FKwBmSDo0npcoIu3ZDQ/eRyIR4ikKTEZSSOYCOhCxnqEIaF93Lta1afQoZWOMTzlGdixViSte7v4xQR/y5OA+HW5zvQvQh/DfhXGpIq6Q1ZFbUvjq/FNuA+NTqDrnB8PwIfRhjFJQ3qRoHQinJKKzNATZwxoXosU8Lfc8ck9yjJVgWfU4CQ4DhiLuFpaH0eKxQqMrHALhhlUdJ5Gb01RqwuCvgULRHXZYKewtVXzip3A3xiBiyKzkmhm1qCMTNM2NYjHsO8L3hhEC2YAKEkjdHZ2FjHeVoWs0i5O4X0tgTIS0zdlO7bJ98UZwBFRcg9DNGAE0/GjglH/pYCP/9Lc9V2hsPKkpFDHccyTkO3jngDPkVzlDGlJFixbEQg12X4OEMpSXjWKocAx6O4zGO9Xh75JAoMvMQpjlC9zS7kTGddXfXsbeCH1h7JdOOtRTJ+VbcD8ki9cLJxejR3DiKxLKM3MgMyO6j/nvWHFMm6hMIJHfRXzOtph2m0OrimSNy+IaJuvBkpvuLvNWW81zYoRJvxur0dv+oLc74zF/KKevYTc23t4Pee84U8J/U6s9dh7PeN7ZQ0Ye9ncWFPEr83zz1lGI2UydrtWWzxqqfO2zB37C2bdAYB7k+SaVS9m+82C/lZdG09/9/XejzhkTyJHVtajUJjBRzX7ptBR6G+d/Y6c96M1UhmFIUa9TqiOJIlCpiPBbdDHpzO4EeHtINZj344tgZcnMR5GwSubVAvMhInpBRRQ0O9uT74MGavr4MfY7Odj80XcWK+bF7XTn9OpK6xflFnHT1xelbu92jo2tZ+FsTBoLtbo9ACXvoeQT0GnfaVrcBwW6fdXChDCrw26ENbefY88MJn5ljV3vSRomiyAVs2WGs94JoDz2zwJK0Q8PTW282NfxFXtV/kvjnUq+ym/bwHjjnwvbJf4MOFLSVen07hk84+AAP5Q7CHA5xce6eZnJtZxdPh+eNrWMPL+Aff2OZlrSjUezb/mAxhaAVV/ahlDYd1H6AD9KWs7xcy/ShrOfhR9Gt//Gu016FPJ4nTqfq1C/3aEbfweRiZT+LY/GDj9ct2Ym43RQ7nV7W9jHPlhE7i9SjUgp8n7Yn3xYtMRQd8F7YDnHcJ2BJPVmu/5kie7B37WfSUqnc6+m2Nm7Ce6PWsQ13fWd+Aft7RGTUoUl6aI6V6Lnpku7nCd3db3x5m7hvkBfga/DzMi/MAfo/SItwlCM4lWpd7ob5FIIZ1yVNzgNt+th5sIQ8nfH3ObNtanfxC6+ApFuTYmuO3R5gP51lh9enWmftQd3hvb6H/DIr7L2RUx1fPINL80YG+OK8FfRT8/TeM2zylF7eaR+PgjqsKPsGrK5BfETBt5xxYzswQM5eDrHqUqvVUP1mKFWHBy7XuS8z9BwgETBuFpihGPcCXrpfCZfUMk5qriqyNGNz5QoulOQYYg+HOUSTyXa+6JtzsPMU3BG87cR7BEBfLp2wKg94k/NItxnq8jWjs+mdQbbkBpvVQPyOBfzH9v1pufBO47M4g/jRdXrAqc/PFcIkpNBLmao5f1g1RbUiKKf5qyXpLfbgDkeEUoQdwXQHLrzhFaoFiq3C1TKhhvNqJf1pfBtXy0JAVU4L1my1FLv3qS5aHtyJJcd8jSjBn+HmtOE/Frb+cBWfpkQlHLkTSeAM6Mf2j/9mthpaOIfaJ+8Xrv+nc0uN4vKhjdl7g9/vxonY3dl6u72zT5Y2xKtst9lTNKzunQiJEc59n/fc/T9ytWK8Ecy33/jJwEmcEZBvBHJztQy/mJ7nbNtudgfl0V3+Bl/ta/kkX+rwUzuXxuRA9tems/X4LuJDbKdfQJb1KoSc4JbEPx5bLOj8OQXxyXfivqwnyc0mCbOWm+A7FYdG9Spmdcp84wZEfc37lM8myqCg1fJ4GTpIS3n6CpKla46HZ5AIbU1CxaRwRVL5QG7r0oPD2zc+T6uo8SQ1JhpY3JaWlKi1Fr8/J1aGQGiDkZd0U9RY/F1oNuh5J3x2S/7vNYcBmMejfPPzi2u38yan8hXbV3efzoalK89Kxgh5/niEPEJf8DzDSdxje1+/H/wAAAP//AwCxlxqZgA4AAA==
+  recorded_at: Thu, 05 Jun 2025 23:03:17 GMT
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/j6gr-cf48?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:03:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - f92cf51e-1f60-41f5-91a3-b285783bbf7b
+      Etag:
+      - W/"b5b6a6e64adf985b22b61732cdd22177"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.208397'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIADYiQmgAA5xX2W7jOhL9lQs9TrcTrR3LwH1w7MTLeIsiS7EaeZAoWqZDLZAob4H/fYpavCU9uDMBAlulU+SphcXjT8F3mSu0PgXiCy1BEu8kVdXU+/WvIG2gpdoUfgpsn2B458ckgyeXsZR4OcMZ9wLjn9ySFC/J7uIt2LJ8WdougcTHESNLglNY8vc7bEEZTiOX4cHtG5Ril8XF06cQuSHn9YyjCKc//xq7KSMRrMftZsl5Bp5x5FKwBmSDo0npcoIu3ZDQ/eRyIR4ikKTEZSSOYCOhCxnqEIaF93Lta1afQoZWOMTzlGdixViSte7v4xQR/y5OA+HW5zvQvQh/DfhXGpIq6Q1ZFbUvjq/FNuA+NTqDrnB8PwIfRhjFJQ3qRoHQinJKKzNATZwxoXosU8Lfc8ck9yjJVgWfU4CQ4DhiLuFpaH0eKxQqMrHALhhlUdJ5Gb01RqwuCvgULRHXZYKewtVXzip3A3xiBiyKzkmhm1qCMTNM2NYjHsO8L3hhEC2YAKEkjdHZ2FjHeVoWs0i5O4X0tgTIS0zdlO7bJ98UZwBFRcg9DNGAE0/GjglH/pYCP/9Lc9V2hsPKkpFDHccyTkO3jngDPkVzlDGlJFixbEQg12X4OEMpSXjWKocAx6O4zGO9Xh75JAoMvMQpjlC9zS7kTGddXfXsbeCH1h7JdOOtRTJ+VbcD8ki9cLJxejR3DiKxLKM3MgMyO6j/nvWHFMm6hMIJHfRXzOtph2m0OrimSNy+IaJuvBkpvuLvNWW81zYoRJvxur0dv+oLc74zF/KKevYTc23t4Pee84U8J/U6s9dh7PeN7ZQ0Ye9ncWFPEr83zz1lGI2UydrtWWzxqqfO2zB37C2bdAYB7k+SaVS9m+82C/lZdG09/9/XejzhkTyJHVtajUJjBRzX7ptBR6G+d/Y6c96M1UhmFIUa9TqiOJIlCpiPBbdDHpzO4EeHtINZj344tgZcnMR5GwSubVAvMhInpBRRQ0O9uT74MGavr4MfY7Odj80XcWK+bF7XTn9OpK6xflFnHT1xelbu92jo2tZ+FsTBoLtbo9ACXvoeQT0GnfaVrcBwW6fdXChDCrw26ENbefY88MJn5ljV3vSRomiyAVs2WGs94JoDz2zwJK0Q8PTW282NfxFXtV/kvjnUq+ym/bwHjjnwvbJf4MOFLSVen07hk84+AAP5Q7CHA5xce6eZnJtZxdPh+eNrWMPL+Aff2OZlrSjUezb/mAxhaAVV/ahlDYd1H6AD9KWs7xcy/ShrOfhR9Gt//Gu016FPJ4nTqfq1C/3aEbfweRiZT+LY/GDj9ct2Ym43RQ7nV7W9jHPlhE7i9SjUgp8n7Yn3xYtMRQd8F7YDnHcJ2BJPVmu/5kie7B37WfSUqnc6+m2Nm7Ce6PWsQ13fWd+Aft7RGTUoUl6aI6V6Lnpku7nCd3db3x5m7hvkBfga/DzMi/MAfo/SItwlCM4lWpd7ob5FIIZ1yVNzgNt+th5sIQ8nfH3ObNtanfxC6+ApFuTYmuO3R5gP51lh9enWmftQd3hvb6H/DIr7L2RUx1fPINL80YG+OK8FfRT8/TeM2zylF7eaR+PgjqsKPsGrK5BfETBt5xxYzswQM5eDrHqUqvVUP1mKFWHBy7XuS8z9BwgETBuFpihGPcCXrpfCZfUMk5qriqyNGNz5QoulOQYYg+HOUSTyXa+6JtzsPMU3BG87cR7BEBfLp2wKg94k/NItxnq8jWjs+mdQbbkBpvVQPyOBfzH9v1pufBO47M4g/jRdXrAqc/PFcIkpNBLmao5f1g1RbUiKKf5qyXpLfbgDkeEUoQdwXQHLrzhFaoFiq3C1TKhhvNqJf1pfBtXy0JAVU4L1my1FLv3qS5aHtyJJcd8jSjBn+HmtOE/Frb+cBWfpkQlHLkTSeAM6Mf2j/9mthpaOIfaJ+8Xrv+nc0uN4vKhjdl7g9/vxonY3dl6u72zT5Y2xKtst9lTNKzunQiJEc59n/fc/T9ytWK8Ecy33/jJwEmcEZBvBHJztQy/mJ7nbNtudgfl0V3+Bl/ta/kkX+rwUzuXxuRA9tems/X4LuJDbKdfQJb1KoSc4JbEPx5bLOj8OQXxyXfivqwnyc0mCbOWm+A7FYdG9Spmdcp84wZEfc37lM8myqCg1fJ4GTpIS3n6CpKla46HZ5AIbU1CxaRwRVL5QG7r0oPD2zc+T6uo8SQ1JhpY3JaWlKi1Fr8/J1aGQGiDkZd0U9RY/F1oNuh5J3x2S/7vNYcBmMejfPPzi2u38yan8hXbV3efzoalK89Kxgh5/niEPEJf8DzDSdxje1+/H/wAAAP//AwCxlxqZgA4AAA==
+  recorded_at: Thu, 05 Jun 2025 23:03:18 GMT
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/j6gr-cf48?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:03:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - cccf58d2-4da1-48bf-a325-898d2de5b5c8
+      Etag:
+      - W/"d486a07904f4a553e84ab17e37160b94"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.200637'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIADciQmgAA5xX2W7jOhL9lQs9TrcTrR3LwH1w7MTLeIsiS7EaeZAoWqZDLZAob4H/fYpavCU9uDMBAlulU+SphcXjT8F3mSu0PgXiCy1BEu8kVdXU+/WvIG2gpdoUfgpsn2B458ckgyeXsZR4OcMZ9wLjn9ySFC/J7uIt2LJ8WdougcTHESNLglNY8vc7bEEZTiOX4cHtG5Ril8XF06cQuSHn9YyjCKc//xq7KSMRrMftZsl5Bp5x5FKwBmSDo0npcoIu3ZDQ/eRyIR4ikKTEZSSOYCOhCxnqEIaF93Lta1afQoZWOMTzlGdixViSte7v4xQR/y5OA+HW5zvQvQh/DfhXGpIq6Q1ZFbUvjq/FNuA+NTqDrnB8PwIfRhjFJQ3qRoHQinJKKzNATZwxoXosU8Lfc8ck9yjJVgWfU4CQ4DhiLuFpaH0eKxQqMrHALhhlUdJ5Gb01RqwuCvgULRHXZYKewtVXzip3A3xiBiyKzkmhm1qCMTNM2NYjHsO8L3hhEC2YAKEkjdHZ2FjHeVoWs0i5O4X0tgTIS0zdlO7bJ98UZwBFRcg9DNGAE0/GjglH/pYCP/9Lc9V2hsPKkpFDHccyTkO3jngDPkVzlDGlJFixbEQg12X4OEMpSXjWKocAx6O4zGO9Xh75JAoMvMQpjlC9zS7kTGddXfXsbeCH1h7JdOOtRTJ+VbcD8ki9cLJxejR3DiKxLKM3MgMyO6j/nvWHFMm6hMIJHfRXzOtph2m0OrimSNy+IaJuvBkpvuLvNWW81zYoRJvxur0dv+oLc74zF/KKevYTc23t4Pee84U8J/U6s9dh7PeN7ZQ0Ye9ncWFPEr83zz1lGI2UydrtWWzxqqfO2zB37C2bdAYB7k+SaVS9m+82C/lZdG09/9/XejzhkTyJHVtajUJjBRzX7ptBR6G+d/Y6c96M1UhmFIUa9TqiOJIlCpiPBbdDHpzO4EeHtINZj344tgZcnMR5GwSubVAvMhInpBRRQ0O9uT74MGavr4MfY7Odj80XcWK+bF7XTn9OpK6xflFnHT1xelbu92jo2tZ+FsTBoLtbo9ACXvoeQT0GnfaVrcBwW6fdXChDCrw26ENbefY88MJn5ljV3vSRomiyAVs2WGs94JoDz2zwJK0Q8PTW282NfxFXtV/kvjnUq+ym/bwHjjnwvbJf4MOFLSVen07hk84+AAP5Q7CHA5xce6eZnJtZxdPh+eNrWMPL+Aff2OZlrSjUezb/mAxhaAVV/ahlDYd1H6AD9KWs7xcy/ShrOfhR9Gt//Gu016FPJ4nTqfq1C/3aEbfweRiZT+LY/GDj9ct2Ym43RQ7nV7W9jHPlhE7i9SjUgp8n7Yn3xYtMRQd8F7YDnHcJ2BJPVmu/5kie7B37WfSUqnc6+m2Nm7Ce6PWsQ13fWd+Aft7RGTUoUl6aI6V6Lnpku7nCd3db3x5m7hvkBfga/DzMi/MAfo/SItwlCM4lWpd7ob5FIIZ1yVNzgNt+th5sIQ8nfH3ObNtanfxC6+ApFuTYmuO3R5gP51lh9enWmftQd3hvb6H/DIr7L2RUx1fPINL80YG+OK8FfRT8/TeM2zylF7eaR+PgjqsKPsGrK5BfETBt5xxYzswQM5eDrHqUqvVUP1mKFWHBy7XuS8z9BwgETBuFpihGPcCXrpfCZfUMk5qriqyNGNz5QoulOQYYg+HOUSTyXa+6JtzsPMU3BG87cR7BEBfLp2wKg94k/NItxnq8jWjs+mdQbbkBpvVQPyOBfzH9v1pufBO47M4g/jRdXrAqc/PFcIkpNBLmao5f1g1RbUiKKf5qyXpLfbgDkeEUoQdwXQHLrzhFaoFiq3C1TKhhvNqJf1pfBtXy0JAVU4L1my1FLv3qS5aHtyJJcd8jSjBn+HmtOE/Frb+cBWfpkQlHLkTSeAM6Mf2j/9mthpaOIfaJ+8Xrv+nc0uN4vKhjdl7g9/vxonY3dl6u72zT5Y2xKtst9lTNKzunQiJEc59n/fc/T9ytWK8Ecy33/jJwEmcEZBvBHJztQy/mJ7nbNtudgfl0V3+Bl/ta/kkX+rwUzuXxuRA9tems/X4LuJDbKdfQJb1KoSc4JbEPx5bLOj8OQXxyXfivqwnyc0mCbOWm+A7FYdG9Spmdcp84wZEfc37lM8myqCg1fJ4GTpIS3n6CpKla46HZ5AIbU1CxaRwRVL5QG7r0oPD2zc+T6uo8SQ1JhpY3JaWlKi1Fr8/J1aGQGiDkZd0U9RY/F1oNuh5J3x2S/7vNYcBmMejfPPzi2u38yan8hXbV3efzoalK89Kxgh5/niEPEJf8DzDSdxje1+/H/wAAAP//AwCxlxqZgA4AAA==
+  recorded_at: Thu, 05 Jun 2025 23:03:19 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.orcid.org/v3.0/0000-0001-6528-2027/work
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <work:work xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:common="http://www.orcid.org/ns/common" xmlns:work="http://www.orcid.org/ns/work" visibility="public" xsi:schemaLocation="http://www.orcid.org/ns/work ../work-3.0.xsd">
+          <work:title>
+            <common:title>Test</common:title>
+          </work:title>
+          <work:journal-title>DataCite</work:journal-title>
+          <work:type>other</work:type>
+          <common:publication-date>
+            <common:year>2019</common:year>
+          </common:publication-date>
+          <common:external-ids>
+            <common:external-id>
+              <common:external-id-type>doi</common:external-id-type>
+              <common:external-id-value>10.14454/j6gr-cf48</common:external-id-value>
+              <common:external-id-relationship>self</common:external-id-relationship>
+            </common:external-id>
+          </common:external-ids>
+          <work:contributors>
+            <work:contributor>
+              <common:contributor-orcid>
+                <common:uri>https://orcid.org/0000-0003-1419-2405</common:uri>
+                <common:path>0000-0003-1419-2405</common:path>
+                <common:host>orcid.org</common:host>
+              </common:contributor-orcid>
+              <work:credit-name>Martin Fenner</work:credit-name>
+            </work:contributor>
+          </work:contributors>
+        </work:work>
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Content-Type:
+      - application/vnd.orcid+xml
+      Authorization:
+      - Bearer TEST_SEARCH_AND_LINK_TOKEN
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:03:19 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 94b34d7b9f476b45-DFW
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-store
+      Pragma:
+      - no-cache
+      Www-Authenticate:
+      - 'Bearer realm="ORCID T2 API", error="invalid_token", error_description="Invalid
+        access token: TEST_SEARCH_AND_LINK_TOKEN"'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Content-Encoding:
+      - gzip
+      X-Target:
+      - reg-sbox-mapi-use2-a1
+      X-Via:
+      - a1
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKrmUlBQSi0qyi9SUrBSUMrMK0vMyUyJL8nPTs1T0oFLxqekFicXZRaUZObngRV6QhQqJCYnpxYXK4DVWymEuAaHxAe7OgY5e8Q7+rnE+3j6eceH+Hu7+ilx1QIAAAD//wMAZy+8J2sAAAA=
+  recorded_at: Thu, 05 Jun 2025 23:03:19 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Claim/process_data_with_source_orcid_search/no_permission_for_auto-update.yml
+++ b/spec/fixtures/vcr_cassettes/Claim/process_data_with_source_orcid_search/no_permission_for_auto-update.yml
@@ -1,0 +1,296 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/j6gr-cf48?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:04:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - 1e260712-3817-4594-9dcb-ee48426ddd61
+      Etag:
+      - W/"2c7a93fdc326fb6c2cf4db54e9223257"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.039189'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJoiQmgAA5xX2W7jOhL9lQs9TrcTrR3LwH1w7MTLeIsiS7EaeZAoWqZDLZAob4H/fYpavCU9uDMBAlulU+SphcXjT8F3mSu0PgXiCy1BEu8kVdXU+/WvIG2gpdoUfgpsn2B458ckgyeXsZR4OcMZ9wLjn9ySFC/J7uIt2LJ8WdougcTHESNLglNY8vc7bEEZTiOX4cHtG5Ril8XF06cQuSHn9YyjCKc//xq7KSMRrMftZsl5Bp5x5FKwBmSDo0npcoIu3ZDQ/eRyIR4ikKTEZSSOYCOhCxnqEIaF93Lta1afQoZWOMTzlGdixViSte7v4xQR/y5OA+HW5zvQvQh/DfhXGpIq6Q1ZFbUvjq/FNuA+NTqDrnB8PwIfRhjFJQ3qRoHQinJKKzNATZwxoXosU8Lfc8ck9yjJVgWfU4CQ4DhiLuFpaH0eKxQqMrHALhhlUdJ5Gb01RqwuCvgULRHXZYKewtVXzip3A3xiBiyKzkmhm1qCMTNM2NYjHsO8L3hhEC2YAKEkjdHZ2FjHeVoWs0i5O4X0tgTIS0zdlO7bJ98UZwBFRcg9DNGAE0/GjglH/pYCP/9Lc9V2hsPKkpFDHccyTkO3jngDPkVzlDGlJFixbEQg12X4OEMpSXjWKocAx6O4zGO9Xh75JAoMvMQpjlC9zS7kTGddXfXsbeCH1h7JdOOtRTJ+VbcD8ki9cLJxejR3DiKxLKM3MgMyO6j/nvWHFMm6hMIJHfRXzOtph2m0OrimSNy+IaJuvBkpvuLvNWW81zYoRJvxur0dv+oLc74zF/KKevYTc23t4Pee84U8J/U6s9dh7PeN7ZQ0Ye9ncWFPEr83zz1lGI2UydrtWWzxqqfO2zB37C2bdAYB7k+SaVS9m+82C/lZdG09/9/XejzhkTyJHVtajUJjBRzX7ptBR6G+d/Y6c96M1UhmFIUa9TqiOJIlCpiPBbdDHpzO4EeHtINZj344tgZcnMR5GwSubVAvMhInpBRRQ0O9uT74MGavr4MfY7Odj80XcWK+bF7XTn9OpK6xflFnHT1xelbu92jo2tZ+FsTBoLtbo9ACXvoeQT0GnfaVrcBwW6fdXChDCrw26ENbefY88MJn5ljV3vSRomiyAVs2WGs94JoDz2zwJK0Q8PTW282NfxFXtV/kvjnUq+ym/bwHjjnwvbJf4MOFLSVen07hk84+AAP5Q7CHA5xce6eZnJtZxdPh+eNrWMPL+Aff2OZlrSjUezb/mAxhaAVV/ahlDYd1H6AD9KWs7xcy/ShrOfhR9Gt//Gu016FPJ4nTqfq1C/3aEbfweRiZT+LY/GDj9ct2Ym43RQ7nV7W9jHPlhE7i9SjUgp8n7Yn3xYtMRQd8F7YDnHcJ2BJPVmu/5kie7B37WfSUqnc6+m2Nm7Ce6PWsQ13fWd+Aft7RGTUoUl6aI6V6Lnpku7nCd3db3x5m7hvkBfga/DzMi/MAfo/SItwlCM4lWpd7ob5FIIZ1yVNzgNt+th5sIQ8nfH3ObNtanfxC6+ApFuTYmuO3R5gP51lh9enWmftQd3hvb6H/DIr7L2RUx1fPINL80YG+OK8FfRT8/TeM2zylF7eaR+PgjqsKPsGrK5BfETBt5xxYzswQM5eDrHqUqvVUP1mKFWHBy7XuS8z9BwgETBuFpihGPcCXrpfCZfUMk5qriqyNGNz5QoulOQYYg+HOUSTyXa+6JtzsPMU3BG87cR7BEBfLp2wKg94k/NItxnq8jWjs+mdQbbkBpvVQPyOBfzH9v1pufBO47M4g/jRdXrAqc/PFcIkpNBLmao5f1g1RbUiKKf5qyXpLfbgDkeEUoQdwXQHLrzhFaoFiq3C1TKhhvNqJf1pfBtXy0JAVU4L1my1FLv3qS5aHtyJJcd8jSjBn+HmtOE/Frb+cBWfpkQlHLkTSeAM6Mf2j/9mthpaOIfaJ+8Xrv+nc0uN4vKhjdl7g9/vxonY3dl6u72zT5Y2xKtst9lTNKzunQiJEc59n/fc/T9ytWK8Ecy33/jJwEmcEZBvBHJztQy/mJ7nbNtudgfl0V3+Bl/ta/kkX+rwUzuXxuRA9tems/X4LuJDbKdfQJb1KoSc4JbEPx5bLOj8OQXxyXfivqwnyc0mCbOWm+A7FYdG9Spmdcp84wZEfc37lM8myqCg1fJ4GTpIS3n6CpKla46HZ5AIbU1CxaRwRVL5QG7r0oPD2zc+T6uo8SQ1JhpY3JaWlKi1Fr8/J1aGQGiDkZd0U9RY/F1oNuh5J3x2S/7vNYcBmMejfPPzi2u38yan8hXbV3efzoalK89Kxgh5/niEPEJf8DzDSdxje1+/H/wAAAP//AwCxlxqZgA4AAA==
+  recorded_at: Thu, 05 Jun 2025 23:04:58 GMT
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/j6gr-cf48?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:04:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - ddb993ab-cc00-44be-be7c-71e1f631d6a7
+      Etag:
+      - W/"f9545ad0dc3c9d873e530ac9fe01acdc"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.120017'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJsiQmgAA5xX2W7jOhL9lQs9TrcTrR3LwH1w7MTLeIsiS7EaeZAoWqZDLZAob4H/fYpavCU9uDMBAlulU+SphcXjT8F3mSu0PgXiCy1BEu8kVdXU+/WvIG2gpdoUfgpsn2B458ckgyeXsZR4OcMZ9wLjn9ySFC/J7uIt2LJ8WdougcTHESNLglNY8vc7bEEZTiOX4cHtG5Ril8XF06cQuSHn9YyjCKc//xq7KSMRrMftZsl5Bp5x5FKwBmSDo0npcoIu3ZDQ/eRyIR4ikKTEZSSOYCOhCxnqEIaF93Lta1afQoZWOMTzlGdixViSte7v4xQR/y5OA+HW5zvQvQh/DfhXGpIq6Q1ZFbUvjq/FNuA+NTqDrnB8PwIfRhjFJQ3qRoHQinJKKzNATZwxoXosU8Lfc8ck9yjJVgWfU4CQ4DhiLuFpaH0eKxQqMrHALhhlUdJ5Gb01RqwuCvgULRHXZYKewtVXzip3A3xiBiyKzkmhm1qCMTNM2NYjHsO8L3hhEC2YAKEkjdHZ2FjHeVoWs0i5O4X0tgTIS0zdlO7bJ98UZwBFRcg9DNGAE0/GjglH/pYCP/9Lc9V2hsPKkpFDHccyTkO3jngDPkVzlDGlJFixbEQg12X4OEMpSXjWKocAx6O4zGO9Xh75JAoMvMQpjlC9zS7kTGddXfXsbeCH1h7JdOOtRTJ+VbcD8ki9cLJxejR3DiKxLKM3MgMyO6j/nvWHFMm6hMIJHfRXzOtph2m0OrimSNy+IaJuvBkpvuLvNWW81zYoRJvxur0dv+oLc74zF/KKevYTc23t4Pee84U8J/U6s9dh7PeN7ZQ0Ye9ncWFPEr83zz1lGI2UydrtWWzxqqfO2zB37C2bdAYB7k+SaVS9m+82C/lZdG09/9/XejzhkTyJHVtajUJjBRzX7ptBR6G+d/Y6c96M1UhmFIUa9TqiOJIlCpiPBbdDHpzO4EeHtINZj344tgZcnMR5GwSubVAvMhInpBRRQ0O9uT74MGavr4MfY7Odj80XcWK+bF7XTn9OpK6xflFnHT1xelbu92jo2tZ+FsTBoLtbo9ACXvoeQT0GnfaVrcBwW6fdXChDCrw26ENbefY88MJn5ljV3vSRomiyAVs2WGs94JoDz2zwJK0Q8PTW282NfxFXtV/kvjnUq+ym/bwHjjnwvbJf4MOFLSVen07hk84+AAP5Q7CHA5xce6eZnJtZxdPh+eNrWMPL+Aff2OZlrSjUezb/mAxhaAVV/ahlDYd1H6AD9KWs7xcy/ShrOfhR9Gt//Gu016FPJ4nTqfq1C/3aEbfweRiZT+LY/GDj9ct2Ym43RQ7nV7W9jHPlhE7i9SjUgp8n7Yn3xYtMRQd8F7YDnHcJ2BJPVmu/5kie7B37WfSUqnc6+m2Nm7Ce6PWsQ13fWd+Aft7RGTUoUl6aI6V6Lnpku7nCd3db3x5m7hvkBfga/DzMi/MAfo/SItwlCM4lWpd7ob5FIIZ1yVNzgNt+th5sIQ8nfH3ObNtanfxC6+ApFuTYmuO3R5gP51lh9enWmftQd3hvb6H/DIr7L2RUx1fPINL80YG+OK8FfRT8/TeM2zylF7eaR+PgjqsKPsGrK5BfETBt5xxYzswQM5eDrHqUqvVUP1mKFWHBy7XuS8z9BwgETBuFpihGPcCXrpfCZfUMk5qriqyNGNz5QoulOQYYg+HOUSTyXa+6JtzsPMU3BG87cR7BEBfLp2wKg94k/NItxnq8jWjs+mdQbbkBpvVQPyOBfzH9v1pufBO47M4g/jRdXrAqc/PFcIkpNBLmao5f1g1RbUiKKf5qyXpLfbgDkeEUoQdwXQHLrzhFaoFiq3C1TKhhvNqJf1pfBtXy0JAVU4L1my1FLv3qS5aHtyJJcd8jSjBn+HmtOE/Frb+cBWfpkQlHLkTSeAM6Mf2j/9mthpaOIfaJ+8Xrv+nc0uN4vKhjdl7g9/vxonY3dl6u72zT5Y2xKtst9lTNKzunQiJEc59n/fc/T9ytWK8Ecy33/jJwEmcEZBvBHJztQy/mJ7nbNtudgfl0V3+Bl/ta/kkX+rwUzuXxuRA9tems/X4LuJDbKdfQJb1KoSc4JbEPx5bLOj8OQXxyXfivqwnyc0mCbOWm+A7FYdG9Spmdcp84wZEfc37lM8myqCg1fJ4GTpIS3n6CpKla46HZ5AIbU1CxaRwRVL5QG7r0oPD2zc+T6uo8SQ1JhpY3JaWlKi1Fr8/J1aGQGiDkZd0U9RY/F1oNuh5J3x2S/7vNYcBmMejfPPzi2u38yan8hXbV3efzoalK89Kxgh5/niEPEJf8DzDSdxje1+/H/wAAAP//AwCxlxqZgA4AAA==
+  recorded_at: Thu, 05 Jun 2025 23:04:59 GMT
+- request:
+    method: get
+    uri: https://api.stage.datacite.org/dois/10.14454/j6gr-cf48?include=media,client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:05:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Anonymous-Consumer:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - '0'
+      X-Request-Id:
+      - ebbb7b6a-ac8c-43b0-8fd2-a155280b3f50
+      Etag:
+      - W/"c02777a7b5317e11c134118f0dd208d0"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.060334'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.27
+      Server:
+      - nginx/1.18.0 + Phusion Passenger(R) 6.0.27
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Accept,Access-Control-Allow-Origin,Access-Control-Expose-Headers,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With
+      Access-Control-Expose-Headers:
+      - Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAJwiQmgAA5xX2W7jOhL9lQs9TrcTrR3LwH1w7MTLeIsiS7EaeZAoWqZDLZAob4H/fYpavCU9uDMBAlulU+SphcXjT8F3mSu0PgXiCy1BEu8kVdXU+/WvIG2gpdoUfgpsn2B458ckgyeXsZR4OcMZ9wLjn9ySFC/J7uIt2LJ8WdougcTHESNLglNY8vc7bEEZTiOX4cHtG5Ril8XF06cQuSHn9YyjCKc//xq7KSMRrMftZsl5Bp5x5FKwBmSDo0npcoIu3ZDQ/eRyIR4ikKTEZSSOYCOhCxnqEIaF93Lta1afQoZWOMTzlGdixViSte7v4xQR/y5OA+HW5zvQvQh/DfhXGpIq6Q1ZFbUvjq/FNuA+NTqDrnB8PwIfRhjFJQ3qRoHQinJKKzNATZwxoXosU8Lfc8ck9yjJVgWfU4CQ4DhiLuFpaH0eKxQqMrHALhhlUdJ5Gb01RqwuCvgULRHXZYKewtVXzip3A3xiBiyKzkmhm1qCMTNM2NYjHsO8L3hhEC2YAKEkjdHZ2FjHeVoWs0i5O4X0tgTIS0zdlO7bJ98UZwBFRcg9DNGAE0/GjglH/pYCP/9Lc9V2hsPKkpFDHccyTkO3jngDPkVzlDGlJFixbEQg12X4OEMpSXjWKocAx6O4zGO9Xh75JAoMvMQpjlC9zS7kTGddXfXsbeCH1h7JdOOtRTJ+VbcD8ki9cLJxejR3DiKxLKM3MgMyO6j/nvWHFMm6hMIJHfRXzOtph2m0OrimSNy+IaJuvBkpvuLvNWW81zYoRJvxur0dv+oLc74zF/KKevYTc23t4Pee84U8J/U6s9dh7PeN7ZQ0Ye9ncWFPEr83zz1lGI2UydrtWWzxqqfO2zB37C2bdAYB7k+SaVS9m+82C/lZdG09/9/XejzhkTyJHVtajUJjBRzX7ptBR6G+d/Y6c96M1UhmFIUa9TqiOJIlCpiPBbdDHpzO4EeHtINZj344tgZcnMR5GwSubVAvMhInpBRRQ0O9uT74MGavr4MfY7Odj80XcWK+bF7XTn9OpK6xflFnHT1xelbu92jo2tZ+FsTBoLtbo9ACXvoeQT0GnfaVrcBwW6fdXChDCrw26ENbefY88MJn5ljV3vSRomiyAVs2WGs94JoDz2zwJK0Q8PTW282NfxFXtV/kvjnUq+ym/bwHjjnwvbJf4MOFLSVen07hk84+AAP5Q7CHA5xce6eZnJtZxdPh+eNrWMPL+Aff2OZlrSjUezb/mAxhaAVV/ahlDYd1H6AD9KWs7xcy/ShrOfhR9Gt//Gu016FPJ4nTqfq1C/3aEbfweRiZT+LY/GDj9ct2Ym43RQ7nV7W9jHPlhE7i9SjUgp8n7Yn3xYtMRQd8F7YDnHcJ2BJPVmu/5kie7B37WfSUqnc6+m2Nm7Ce6PWsQ13fWd+Aft7RGTUoUl6aI6V6Lnpku7nCd3db3x5m7hvkBfga/DzMi/MAfo/SItwlCM4lWpd7ob5FIIZ1yVNzgNt+th5sIQ8nfH3ObNtanfxC6+ApFuTYmuO3R5gP51lh9enWmftQd3hvb6H/DIr7L2RUx1fPINL80YG+OK8FfRT8/TeM2zylF7eaR+PgjqsKPsGrK5BfETBt5xxYzswQM5eDrHqUqvVUP1mKFWHBy7XuS8z9BwgETBuFpihGPcCXrpfCZfUMk5qriqyNGNz5QoulOQYYg+HOUSTyXa+6JtzsPMU3BG87cR7BEBfLp2wKg94k/NItxnq8jWjs+mdQbbkBpvVQPyOBfzH9v1pufBO47M4g/jRdXrAqc/PFcIkpNBLmao5f1g1RbUiKKf5qyXpLfbgDkeEUoQdwXQHLrzhFaoFiq3C1TKhhvNqJf1pfBtXy0JAVU4L1my1FLv3qS5aHtyJJcd8jSjBn+HmtOE/Frb+cBWfpkQlHLkTSeAM6Mf2j/9mthpaOIfaJ+8Xrv+nc0uN4vKhjdl7g9/vxonY3dl6u72zT5Y2xKtst9lTNKzunQiJEc59n/fc/T9ytWK8Ecy33/jJwEmcEZBvBHJztQy/mJ7nbNtudgfl0V3+Bl/ta/kkX+rwUzuXxuRA9tems/X4LuJDbKdfQJb1KoSc4JbEPx5bLOj8OQXxyXfivqwnyc0mCbOWm+A7FYdG9Spmdcp84wZEfc37lM8myqCg1fJ4GTpIS3n6CpKla46HZ5AIbU1CxaRwRVL5QG7r0oPD2zc+T6uo8SQ1JhpY3JaWlKi1Fr8/J1aGQGiDkZd0U9RY/F1oNuh5J3x2S/7vNYcBmMejfPPzi2u38yan8hXbV3efzoalK89Kxgh5/niEPEJf8DzDSdxje1+/H/wAAAP//AwCxlxqZgA4AAA==
+  recorded_at: Thu, 05 Jun 2025 23:05:00 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.orcid.org/v3.0/0000-0001-6528-2027/work
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <work:work xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:common="http://www.orcid.org/ns/common" xmlns:work="http://www.orcid.org/ns/work" visibility="public" xsi:schemaLocation="http://www.orcid.org/ns/work ../work-3.0.xsd">
+          <work:title>
+            <common:title>Test</common:title>
+          </work:title>
+          <work:journal-title>DataCite</work:journal-title>
+          <work:type>other</work:type>
+          <common:publication-date>
+            <common:year>2019</common:year>
+          </common:publication-date>
+          <common:external-ids>
+            <common:external-id>
+              <common:external-id-type>doi</common:external-id-type>
+              <common:external-id-value>10.14454/j6gr-cf48</common:external-id-value>
+              <common:external-id-relationship>self</common:external-id-relationship>
+            </common:external-id>
+          </common:external-ids>
+          <work:contributors>
+            <work:contributor>
+              <common:contributor-orcid>
+                <common:uri>https://orcid.org/0000-0003-1419-2405</common:uri>
+                <common:path>0000-0003-1419-2405</common:path>
+                <common:host>orcid.org</common:host>
+              </common:contributor-orcid>
+              <work:credit-name>Martin Fenner</work:credit-name>
+            </work:contributor>
+          </work:contributors>
+        </work:work>
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/5.0.0; mailto:info@datacite.org)
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+      Content-Type:
+      - application/vnd.orcid+xml
+      Authorization:
+      - Bearer TEST_SEARCH_AND_LINK_TOKEN
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Thu, 05 Jun 2025 23:05:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 94b34ff1ac796786-DFW
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-store
+      Pragma:
+      - no-cache
+      Www-Authenticate:
+      - 'Bearer realm="ORCID T2 API", error="invalid_token", error_description="Invalid
+        access token: TEST_SEARCH_AND_LINK_TOKEN"'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Content-Encoding:
+      - gzip
+      X-Target:
+      - reg-sbox-mapi-use2-a1
+      X-Via:
+      - a1
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKrmUlBQSi0qyi9SUrBSUMrMK0vMyUyJL8nPTs1T0oFLxqekFicXZRaUZObngRV6QhQqJCYnpxYXK4DVWymEuAaHxAe7OgY5e8Q7+rnE+3j6eceH+Hu7+ilx1QIAAAD//wMAZy+8J2sAAAA=
+  recorded_at: Thu, 05 Jun 2025 23:05:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -19,116 +19,136 @@ describe Claim, type: :model, vcr: true, elasticsearch: true do
   #   end
   # end
 
-  describe "collect_data", order: :defined do
+  describe "claim uses correct token" do
     let(:user) { FactoryBot.create(:valid_user) }
-    let(:put_code) { 1069293 }
 
-    subject { FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/1X4X-9056") }
-
-    # it 'no errors' do
-    #   response = subject.collect_data
-    #   expect(response.body["errors"]).to eq([{"title"=>"Missing data"}])
-    #   expect(response.body["put_code"]).to be_nil
-    #   expect(response.status).to eq(201)
-    # end
-
-    # TODO
-    # it "already exists" do
-    #   FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/1X4X-9056", claim_action: "create", put_code: put_code)
-    #   expect(subject.collect_data.body).to eq("reason" => "already claimed.", "skip" => true)
-    # end
-
-    # it 'delete claim' do
-    #   user = FactoryBot.create(:valid_user)
-    #   subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/1X4X-9056", claim_action: "delete", claimed_at: Time.zone.now, put_code: put_code)
-    #   response = subject.collect_data
-    #   expect(response.body["data"]).to be_blank
-    #   expect(response.body["errors"]).to eq([{"title"=>"Missing data"}])
-    # end
-
-    it "no permission for auto-update" do
+    it "uses the auto update token" do
       user = FactoryBot.create(:valid_user, auto_update: false)
-      subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/v6e2-yc93", source_id: "orcid_update")
-      response = subject.collect_data
-      expect(response.body).to eq({ "errors" => [{ "title" => "No auto-update permission" }] })
+      subject = FactoryBot.create(:claim, user: user, source_id: "orcid_update")
+      expect(subject.orcid_token).to eq(user.orcid_token)
     end
 
-    it "missing token" do
-      user = FactoryBot.create(:invalid_user)
-      subject = FactoryBot.create(:claim, user: user, orcid: "0000-0003-1419-240x", doi: "10.14454/v6e2-yc93", source_id: "orcid_update")
-      response = subject.collect_data
-      expect(response.body).to eq({ "errors" => [{ "title" => "No user and/or ORCID token" }] })
-    end
-
-    it "expired token" do
-      user = FactoryBot.create(:valid_user, orcid_expires_at: Time.zone.now - 7.days)
-      subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/1X4X-9056", source_id: "orcid_update")
-      response = subject.collect_data
-      expect(response.body).to eq("errors" => [{ "status" => 401, "title" => "token has expired." }])
-    end
-
-    # TODO
-    # it "invalid token" do
-    #   user = FactoryBot.create(:invalid_user, orcid_token: "123")
-    #   subject = FactoryBot.create(:claim, user: user, orcid: "0000-0003-1419-240x", doi: "10.14454/v6e2-yc93", source_id: "orcid_update")
-    #   response = subject.collect_data
-    #   expect(response.body).to eq("errors"=>[{"title"=>"Missing data"}])
-    # end
-
-    it "no user" do
-      subject = FactoryBot.create(:claim, orcid: "0000-0001-6528-2027", doi: "10.14454/v6e2-yc93")
-      response = subject.collect_data
-      expect(response.body).to eq("errors" => [{ "title" => "No user and/or ORCID token" }])
+    it "uses the search and link token" do
+      user = FactoryBot.create(:valid_user, auto_update: false)
+      subject = FactoryBot.create(:claim, user: user, source_id: "orcid_search")
+      expect(subject.orcid_token).to eq(user.orcid_search_and_link_access_token)
     end
   end
 
-  describe "process_data", order: :defined do
-    let(:user) { FactoryBot.create(:valid_user) }
-    let(:put_code) { 1069294 }
+  sources = [ "orcid_search", "orcid_update" ]
+  sources.each do |source|
+    describe "collect_data with source #{source}", order: :defined do
+      let(:user) { FactoryBot.create(:valid_user) }
+      let(:put_code) { 1069293 }
 
-    subject { FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48") }
+      subject { FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/1X4X-9056") }
 
-    # it 'no errors' do
-    #   expect(subject.process_data).to be true
-    #   expect(subject.put_code).to be_blank
-    #   expect(subject.claimed_at).to be_blank
-    #   expect(subject.state).to eq("failed")
-    # end
+      # it 'no errors' do
+      #   response = subject.collect_data
+      #   expect(response.body["errors"]).to eq([{"title"=>"Missing data"}])
+      #   expect(response.body["put_code"]).to be_nil
+      #   expect(response.status).to eq(201)
+      # end
 
-    # TODO
-    # it "already exists" do
-    #   FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48", claim_action: "create", put_code: put_code)
-    #   expect(subject.process_data).to be true
-    #   expect(subject.state).to eq("done")
-    # end
+      # TODO
+      # it "already exists" do
+      #   FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/1X4X-9056", claim_action: "create", put_code: put_code)
+      #   expect(subject.collect_data.body).to eq("reason" => "already claimed.", "skip" => true)
+      # end
 
-    # it 'delete claim' do
-    #   user = FactoryBot.create(:valid_user)
-    #   subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48", claim_action: "delete", put_code: put_code)
-    #   expect(subject.process_data).to be true
-    #   expect(subject.put_code).to eq(1069294)
-    #   expect(subject.claimed_at).to be_blank
-    #   expect(subject.state).to eq("failed")
-    # end
+      # it 'delete claim' do
+      #   user = FactoryBot.create(:valid_user)
+      #   subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/1X4X-9056", claim_action: "delete", claimed_at: Time.zone.now, put_code: put_code)
+      #   response = subject.collect_data
+      #   expect(response.body["data"]).to be_blank
+      #   expect(response.body["errors"]).to eq([{"title"=>"Missing data"}])
+      # end
 
-    it "no permission for auto-update" do
-      user = FactoryBot.create(:valid_user, auto_update: false)
-      subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48", source_id: "orcid_update")
-      expect(subject.process_data).to be true
-      expect(subject.state).to eq("failed") # This used to be 'ignored' but the code is correctly returning an error struct and thus setting it to failed
+      ## This test is no longer necessary as the auto_update flag has been replaced by presence of auto_update token
+      # it "no permission for auto-update" do
+      #   user = FactoryBot.create(:valid_user, auto_update: false)
+      #   subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/v6e2-yc93", source_id: "orcid_update")
+      #   response = subject.collect_data
+      #   expect(response.body).to eq({ "errors" => [{ "title" => "No auto-update permission" }] })
+      # end
+
+      it "missing token" do
+        user = FactoryBot.create(:invalid_user)
+        subject = FactoryBot.create(:claim, user: user, orcid: "0000-0003-1419-240x", doi: "10.14454/v6e2-yc93", source_id: source)
+        response = subject.collect_data
+        expect(response.body).to eq({ "errors" => [{ "title" => "No user and/or ORCID token" }] })
+      end
+
+      it "expired token" do
+        user = FactoryBot.create(:valid_user, orcid_expires_at: Time.zone.now - 7.days, orcid_search_and_link_expires_at: Time.zone.now - 7.days)
+        subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/1X4X-9056", source_id: source)
+        response = subject.collect_data
+        expect(response.body).to eq("errors" => [{ "status" => 401, "title" => "token has expired." }])
+      end
+
+      # TODO
+      # it "invalid token" do
+      #   user = FactoryBot.create(:invalid_user, orcid_token: "123")
+      #   subject = FactoryBot.create(:claim, user: user, orcid: "0000-0003-1419-240x", doi: "10.14454/v6e2-yc93", source_id: "orcid_update")
+      #   response = subject.collect_data
+      #   expect(response.body).to eq("errors"=>[{"title"=>"Missing data"}])
+      # end
+
+      it "no user" do
+        subject = FactoryBot.create(:claim, orcid: "0000-0001-6528-2027", doi: "10.14454/v6e2-yc93")
+        response = subject.collect_data
+        expect(response.body).to eq("errors" => [{ "title" => "No user and/or ORCID token" }])
+      end
     end
 
-    it "invalid token" do
-      user = FactoryBot.create(:invalid_user)
-      subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48", source_id: "orcid_update")
-      expect(subject.process_data).to be true
-      expect(subject.state).to eq("failed") # This used to be 'ignored' but the code is correctly returning an error struct and thus setting it to failed
-    end
+    describe "process_data with source #{source}", order: :defined do
+      let(:user) { FactoryBot.create(:valid_user) }
+      let(:put_code) { 1069294 }
 
-    it "no user" do
-      subject = FactoryBot.build(:claim, user: nil, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48")
-      expect(subject.valid?).to be false
-      expect(subject.errors[:user]).to include("must exist")
+      subject { FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48") }
+
+      # it 'no errors' do
+      #   expect(subject.process_data).to be true
+      #   expect(subject.put_code).to be_blank
+      #   expect(subject.claimed_at).to be_blank
+      #   expect(subject.state).to eq("failed")
+      # end
+
+      # TODO
+      # it "already exists" do
+      #   FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48", claim_action: "create", put_code: put_code)
+      #   expect(subject.process_data).to be true
+      #   expect(subject.state).to eq("done")
+      # end
+
+      # it 'delete claim' do
+      #   user = FactoryBot.create(:valid_user)
+      #   subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48", claim_action: "delete", put_code: put_code)
+      #   expect(subject.process_data).to be true
+      #   expect(subject.put_code).to eq(1069294)
+      #   expect(subject.claimed_at).to be_blank
+      #   expect(subject.state).to eq("failed")
+      # end
+
+      it "no permission for auto-update" do
+        user = FactoryBot.create(:valid_user, auto_update: false)
+        subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48", source_id: source)
+        expect(subject.process_data).to be true
+        expect(subject.state).to eq("failed") # This used to be 'ignored' but the code is correctly returning an error struct and thus setting it to failed
+      end
+
+      it "invalid token" do
+        user = FactoryBot.create(:invalid_user)
+        subject = FactoryBot.create(:claim, user: user, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48", source_id: source)
+        expect(subject.process_data).to be true
+        expect(subject.state).to eq("failed") # This used to be 'ignored' but the code is correctly returning an error struct and thus setting it to failed
+      end
+
+      it "no user" do
+        subject = FactoryBot.build(:claim, user: nil, orcid: "0000-0001-6528-2027", doi: "10.14454/j6gr-cf48")
+        expect(subject.valid?).to be false
+        expect(subject.errors[:user]).to include("must exist")
+      end
     end
   end
 end


### PR DESCRIPTION
## Purpose
We should be using different client credentials when performing auto-updates vs search and link claims. Presently all ORCID actions use the same credentials/token for authentication in Profiles.

closes: https://github.com/datacite/product-backlog/issues/270

## Approach

- Added three new columns to the user table: `orcid_search_and_link_access_token`, `orcid_search_and_link_refresh_token`, `orcid_search_and_link_expires_at`
- Added a new `/orcid` endpoint for handling token fetching for Search and Link
- Added a button on the settings page that uses the new OrcidController to fetch/revoke a user's search and link token
- Updated claiming to use the appropriate token depending on whether the claim `source_id` is `orcid_update` or `orcid_search`
- Added tests to verify the implementation



#### Open Questions and Pre-Merge TODOs
- [ ] I need to clarify with ORCID if we should use separate credentials for user auth and auto-update
- [ ] Do we need to sort out the previous claims? 

## Learning

Combed through the volpino code to better understand how/where the claiming happens. Familiarized myself more with Ruby/Rails in general during this process, especially in regards to routing and [requesting with Faraday](https://lostisland.github.io/faraday/#/getting-started/quick-start).

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
