### PR TITLE
Use dynamic row format on the users table

### DIFF
--- a/db/migrate/20250603132805_add_orcid_search_and_link_tokens_to_users.rb
+++ b/db/migrate/20250603132805_add_orcid_search_and_link_tokens_to_users.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 class AddOrcidSearchAndLinkTokensToUsers < ActiveRecord::Migration[7.1]
+  def up
+    execute "ALTER TABLE users ROW_FORMAT=DYNAMIC"
+  end
+
   def change
-    add_column :users, :orcid_search_and_link_access_token, :text
-    add_column :users, :orcid_search_and_link_refresh_token, :text
+    add_column :users, :orcid_search_and_link_access_token, :string
+    add_column :users, :orcid_search_and_link_refresh_token, :string
     add_column :users, :orcid_search_and_link_expires_at, :datetime
+  end
+
+  def down
+    execute "ALTER TABLE users ROW_FORMAT=COMPACT"
   end
 end

--- a/db/migrate/20250606171151_update_orcid_token_columns.rb
+++ b/db/migrate/20250606171151_update_orcid_token_columns.rb
@@ -7,8 +7,8 @@ class UpdateOrcidTokenColumns < ActiveRecord::Migration[7.1]
     rename_column :users, :orcid_expires_at, :orcid_auto_update_expires_at
 
     # Add new columns
-    add_column :users, :orcid_token, :text
+    add_column :users, :orcid_token, :string
     add_column :users, :orcid_expires_at, :datetime
-    add_column :users, :orcid_auto_update_refresh_token, :text
+    add_column :users, :orcid_auto_update_refresh_token, :string
   end
 end


### PR DESCRIPTION
## Purpose
Use `ROW_FORMAT=DYNAMIC` to circumvent the `Row size too large` error in Mysql

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
