### PR TITLE
user's ORCID iD links to ORCID instead of Profiles settings

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -264,7 +264,7 @@ class User < ApplicationRecord
   end
 
   def orcid_as_url
-    Rails.env.test? ? ENV["ORCID_URL"] + "/" + orcid : "https://orcid.org/" + orcid
+    ENV["ORCID_URL"] ? ENV["ORCID_URL"] + "/" + orcid : "https://orcid.org/" + orcid
   end
 
   def flipper_id

--- a/app/views/settings/_show.html.erb
+++ b/app/views/settings/_show.html.erb
@@ -2,7 +2,7 @@
   <div class="col-md-9">
     <div class="panel-body settings-container">
       <h2 class="settings-name col-span-full"><%= @user.name %></h2>
-      <p class="settings-orcid-link col-span-full"><%= link_to @user.orcid_as_url, @user.orcid %></p>
+      <%= link_to @user.orcid_as_url, @user.orcid_as_url, class: "settings-orcid-link col-span-full" %>
 
       <h3 class="settings-section-header col-span-full">Link Works to ORCID
         <% if @user.orcid_search_and_link_access_token %>


### PR DESCRIPTION
## Purpose
Make user's ORCID iD in settings link to ORCID instead of back to the Profiles settings page

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
