### PR TITLE
Remove queueing claim jobs on user create

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,6 @@ class User < ApplicationRecord
   before_create :set_role
 
   after_commit :queue_user_job, on: :create
-  after_commit :queue_claim_jobs, on: :create
 
   has_many :claims, primary_key: "uid", foreign_key: "orcid", inverse_of: :user
 


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

The user model attempts to queue all failed claim jobs on user create. This seems to be a leftover from an incomplete ORCID notification implementation, likely wouldn't work on user create because the correct ORCID credentials wouldn't have been added by the user yet, and should be a user-initiated action regardless. This PR removes the callback. See the commit message here for more context:

- https://github.com/datacite/volpino/commit/3bc335a76ef07a02a65527d4d27fe1ac5b70762f

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
